### PR TITLE
CI Test suite for multiple enviroments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 permissions: "read-all"
 
 jobs:
-  run-linting:
+  linting:
     name: linting via pre-commit 
     runs-on: ubuntu-latest
 
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Install pre-commit
         run: |
           pip install --upgrade pip 
@@ -26,8 +26,8 @@ jobs:
       - name: Run pre-commit steps
         run: |
           pre-commit run --all-files
-  run-tests:
-    name: tests via pytest
+  test-coverage:
+    name: Test base configuration with coverage
     runs-on: ubuntu-latest
 
     steps:
@@ -36,17 +36,44 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           pip install --upgrade pip 
           pip install -e .[dev,audit]
       - name: Run tests
         run: |
-          pytest .
+          coverage run -m pytest
+      - name: Generate coverage report
+        run: |
+          coverage xml
+      - name: Generate htmp report for inspection
+        if: failure()
+        run: |
+          coverage html
       - name: Upload coverage
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-data
           path: coverage/coverage.xml
           if-no-files-found: error
+  test-packaging:
+    name: Test packaging
+    runs-on: ubuntu-latest
+  
+    steps: 
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip 
+          pip install build twine
+      - name: Build package
+        run: |
+          python -m build
+          python -m twine check dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,37 @@ jobs:
         run: |
           python -m build
           python -m twine check dist/*
+  test-versions:
+    # Limit matrix to after base is passing
+    needs: [test-coverage, linting, test-packaging]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        include:
+          - experimental: false
+          # Install is not robust in 3.12
+          - python-version: "3.12"
+            experimental: true
+      
+    name: Test python-${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip 
+          pip install -e .[dev,audit]
+      - name: Run tests
+        run: |
+          pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions: "read-all"
 
 jobs:
   linting:
-    name: linting via pre-commit 
+    name: Linting
     runs-on: ubuntu-latest
 
     steps:
@@ -27,7 +27,7 @@ jobs:
         run: |
           pre-commit run --all-files
   test-coverage:
-    name: Test base configuration with coverage
+    name: Coverage py3.10
     runs-on: ubuntu-latest
 
     steps:
@@ -44,19 +44,19 @@ jobs:
       - name: Run tests
         run: |
           coverage run -m pytest
-      - name: Generate coverage report
+      - name: Generate xml
         run: |
           coverage xml
-      - name: Generate htmp report for inspection
+      - name: Generate html
         if: failure()
         run: |
           coverage html
-      - name: Upload coverage
+      - name: Upload report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-data
-          path: coverage/coverage.xml
+          path: coverage/*
           if-no-files-found: error
   test-packaging:
     name: Test packaging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,16 +84,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11"]
         os:
           - ubuntu-latest
           - windows-latest
           - macos-latest
         include:
           - experimental: false
-          # Install is not robust in 3.12
-          - python-version: "3.12"
-            experimental: true
       
     name: Test python-${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,10 @@ jobs:
       - name: Run tests
         run: |
           coverage run -m pytest
-      - name: Generate xml
+      - name: Generate report
         run: |
           coverage xml
+          coverage report
       - name: Generate html
         if: failure()
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ source = seismometer
 branch = True
 
 [coverage:report]
-fail_under = 90
+fail_under = 70
 omit =
     */plot/mpl/*
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ all =
 audit =
     aequitas>=1.0.0
 dev =
+    coverage>=7.5.1
     autopep8>=1.3.5
     pytest-json>=0.4.0
     pytest>=5.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,6 @@ audit =
     aequitas>=1.0.0
 dev =
     autopep8>=1.3.5
-    pytest-cov>=2.5.1
     pytest-json>=0.4.0
     pytest>=5.1.1
     traitlets>=5.1.1
@@ -71,24 +70,25 @@ docs =
 
 
 [tool:pytest]
-addopts = --cov-config=setup.cfg --cov=seismometer --cov-report=term --cov-report=html --cov-report=xml:coverage/coverage.xml
 testpaths = tests
-json_report = coverage/test-report.json
-jsonapi = True
 filterwarnings =
     ignore::UserWarning
     ignore::PendingDeprecationWarning
 
 [coverage:run]
+source = seismometer
 branch = True
 
 [coverage:report]
-fail_under = 70
+fail_under = 90
 omit =
     */plot/mpl/*
 
 [coverage:html]
 directory = coverage/html-report
+
+[coverage:xml]
+output = coverage/coverage.xml
 
 [tool:isort]
 line_length = 119


### PR DESCRIPTION
# Overview
Updates CI for test coverage

## Description of changes
Coverage should be done on base environment (py3.10 + linux) since there is no dependent branching  
Test suite should run on:  
- linux, macos, windows  
- python 3.10 and 3.11

3.12 has known install issue to resolve before adding - marked as experimental allowing failure  


Using a runner matrix allowed for testing across environments and python versions **without** actually using nox.  While this isn't easily reproducible on a single machine, it seems reasonable to forgo defining the nox sessions until we need more complexity. Testing multiple environments in a single python version might be reason to start using sessions (such as ensuring compatibility with multiple versions of pandas)

## Author Checklist
- [X] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
