### PR TITLE
Fix pages action by removing deprecated extension

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,7 +10,7 @@ jobs:
     name: changelog entry
     runs-on: ubuntu-latest
     # skip job if label is present
-    if: ! contains(github.event.pull_request.labels.*.name, 'skip changelog')
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip changelog')"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,7 +10,7 @@ jobs:
     name: changelog entry
     runs-on: ubuntu-latest
     # skip job if label is present
-    if: "!contains(github.event.pull_request.labels.*.name, 'skip changelog')"
+    if: ! contains(github.event.pull_request.labels.*.name, 'skip changelog')
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,6 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
     "sphinxawesome_theme",
-    "sphinxawesome_theme.highlighting",
     "sphinxcontrib.autodoc_pydantic",
     "sphinx.ext.intersphinx",
     "sphinx_design",


### PR DESCRIPTION
# Overview
Remove sphinxawesome_theme.highlighting extension as it was recently deprecated and its deprecation warning breaks our pages action

## Author Checklist
- [x] Build and review generated docs
- [x] Ensure Pages action completes successfully
