### PR TITLE
Update README.md - add Docs badge and link License badge to license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Install the packages required for fairness audit visualizations with:
 
 ## Getting Help
 
-For general usage questions, refer to our User Guide.
+For general usage questions, refer to our [User Guide](https://epic-open-source.github.io/seismometer/user_guide/index.html#user-guide).
 
-Report any bugs or enhancement suggestions using our Issues page.  
+Report any bugs or enhancement suggestions using our [Issues page](https://github.com/epic-open-source/seismometer/issues).  
 
 If you have questions or feedback, e-mail <OpenSourceContributions-Python@epic.com>.
 
@@ -41,4 +41,4 @@ If you have questions or feedback, e-mail <OpenSourceContributions-Python@epic.c
 
 We welcome contributions, bug reports, bug fixes, documentation improvements, enhancements, and ideas.
 
-Refer to the Contribution Guide for more details.
+Refer to the [Contribution Guide](https://epic-open-source.github.io/seismometer/development/index.html) for more details.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Seismometer
 
+[![Docs](https://img.shields.io/badge/docs-stable-blue)](https://epic-open-source.github.io/seismometer/)
 [![PyPI](https://img.shields.io/pypi/v/seismometer)](https://pypi.org/project/seismometer/)
-![GitHub License](https://img.shields.io/github/license/epic-open-source/seismometer)
+[![GitHub License](https://img.shields.io/github/license/epic-open-source/seismometer)](https://github.com/epic-open-source/seismometer/blob/main/LICENSE.txt)
 ![CodeQL](https://github.com/epic-open-source/seismometer/workflows/CodeQL/badge.svg)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/seismometer)
 


### PR DESCRIPTION
# Overview
- The documentation is linked at the top-right of the repository page but not within the README itself
- The License badge, when clicked, points to the image of the badge rather than the text of the license

## Description of changes
- Adds a documentation badge to the front of the README to make it easy to find
- Points the License badge to the License.txt file within the repository

## Author Checklist
- Happy to update the changelog but since the changes only affect the README, not sure if needed

- [N/A] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [N/A] Tests added for new code and issue being fixed.
- [N/A] Added type annotations and full numpy-style docstrings for new methods.
- [Needed?] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
