### PR TITLE
Make label checks more dynamic

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,11 +6,28 @@ on:
 permissions: "read-all"
 
 jobs:
+  # Check for label in its own job to allow skipping multiple steps with 'success'
+  check-changelog-needed:
+    name: changelog needed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Labels
+        id: check_labels
+        env:
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_ID: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          labels="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PR_ID --jq '.labels.[].name')"
+          if [[ $labels != *"skip changelog"* ]]; then
+            echo "needs_entry=true" >> "$GITHUB_OUTPUT"
+          fi
+
   check-changelog-entry:
     name: changelog entry
     runs-on: ubuntu-latest
-    # skip job if label is present
-    if: "!contains(github.event.pull_request.labels.*.name, 'skip changelog')"
+    if: ${{ steps.check_labels.outputs.needs_entry == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,12 +7,11 @@ permissions: "read-all"
 
 jobs:
   # Check for label in its own job to allow skipping multiple steps with 'success'
-  check-changelog-needed:
-    name: changelog needed
+  check-labels:
+    name: check labels
     runs-on: ubuntu-latest
     steps:
-      - name: Check Labels
-        id: check_labels
+      - id: check-labels
         env:
           OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
@@ -22,12 +21,17 @@ jobs:
           labels="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PR_ID --jq '.labels.[].name')"
           if [[ $labels != *"skip changelog"* ]]; then
             echo "needs_entry=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_entry=false" >> "$GITHUB_OUTPUT"
           fi
+    outputs:
+      needs_entry: ${{ steps.check-labels.outputs.needs_entry }}
 
   check-changelog-entry:
-    name: changelog entry
+    name: has fragment
     runs-on: ubuntu-latest
-    if: ${{ steps.check_labels.outputs.needs_entry == 'true' }}
+    needs: check-labels
+    if: ${{ needs.check-labels.outputs.needs_entry == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,7 +3,8 @@ name: Changelog
 on:
   pull_request: {}
 
-permissions: "read-all"
+permissions: 
+  pull-requests: read
 
 jobs:
   # Check for label in its own job to allow skipping multiple steps with 'success'
@@ -28,7 +29,7 @@ jobs:
       needs_entry: ${{ steps.check-labels.outputs.needs_entry }}
 
   check-changelog-entry:
-    name: has fragment
+    name: has changelog fragment
     runs-on: ubuntu-latest
     needs: check-labels
     if: ${{ needs.check-labels.outputs.needs_entry == 'true' }}


### PR DESCRIPTION
# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->
Closes #22 

## Description of changes
Use gh api to request labels dynamically instead of using the cached list that requires an event (commit) to renew. 
Split changelog workflow into two jobs; could not find a method for short-circuiting success within a job.  

Note: this method is intentionally requiring manual retry, and NOT triggering off of label changes

Suggested testing-  
As a step 0, I'm intentionally NOT setting labels prior to PR creation.  
Tests can add and remove labels on this PR, then manually rerun the specific workflow.  
Verify that the second job runs and is skipped depending on the skip-changelog label.  
Before merge, update labels and drop the second commit to verify the push event also behaves correctly

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
