### PR TITLE
Fix; Wrap sm.show_info table header in <thead>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ scripted_testing/
 /output/
 /notebooks/output/
 /notebooks/data/
+example-notebooks/binary-classifier/dictionary.yml
+example-notebooks/binary-classifier/data/*
+example-notebooks/binary-classifier/outputs/*

--- a/changelog/24.bugfix.rst
+++ b/changelog/24.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes the header of sm.show_info() to start the table zebra stripe on the right row.

--- a/src/seismometer/html/resources/info.html
+++ b/src/seismometer/html/resources/info.html
@@ -7,12 +7,14 @@
 <h3>Summary</h3>
 The preloaded data covers {{ num_predictions }} predictions over {{ num_entities }} entities from the dates {{ start_date }} to {{ end_date }}.
 <table>
-    <tr>
-    <th>Dataframe Name</th>
-    <th>Rows</th>
-    <th>Columns</th>
-    <th>Content</th>
-    </tr>
+    <thead>
+        <tr>
+        <th>Dataframe Name</th>
+        <th>Rows</th>
+        <th>Columns</th>
+        <th>Content</th>
+        </tr>
+    </thead>
     {% for table in tables %}
     <tr>
     <td><code>{{ table["name"] }}</code></td>

--- a/tests/resources/rendered_templates/info.html
+++ b/tests/resources/rendered_templates/info.html
@@ -7,12 +7,14 @@
 <h3>Summary</h3>
 The preloaded data covers num_predictions predictions over num_entities entities from the dates start_date to end_date.
 <table>
-    <tr>
-    <th>Dataframe Name</th>
-    <th>Rows</th>
-    <th>Columns</th>
-    <th>Content</th>
-    </tr>
+    <thead>
+        <tr>
+        <th>Dataframe Name</th>
+        <th>Rows</th>
+        <th>Columns</th>
+        <th>Content</th>
+        </tr>
+    </thead>
     <tr>
     <td><code>sg.dataframe</code></td>
     <td>1</td>

--- a/tests/resources/rendered_templates/info_no_plot_help.html
+++ b/tests/resources/rendered_templates/info_no_plot_help.html
@@ -7,12 +7,14 @@
 <h3>Summary</h3>
 The preloaded data covers num_predictions predictions over num_entities entities from the dates start_date to end_date.
 <table>
-    <tr>
-    <th>Dataframe Name</th>
-    <th>Rows</th>
-    <th>Columns</th>
-    <th>Content</th>
-    </tr>
+    <thead>
+        <tr>
+        <th>Dataframe Name</th>
+        <th>Rows</th>
+        <th>Columns</th>
+        <th>Content</th>
+        </tr>
+    </thead>
     <tr>
     <td><code>sg.dataframe</code></td>
     <td>1</td>


### PR DESCRIPTION
# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->
Fixes the header to be thead to pull in the right header css and to start the table contents zebra stripe on the right row. Cosmetic only. 

## Description of changes
Found the jinja template from sm.show_info,() and added <thead> and </thead> around the table header.

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
