### PR TITLE
Add FilterRule.all() and FilterRule.none() rules + user readable display string

### DIFF
--- a/changelog/27.feature.rst
+++ b/changelog/27.feature.rst
@@ -1,0 +1,1 @@
+* Added `FilterRule.all()` and `FilterRule.none()` class methods for matching all or no rows of a dataframe.

--- a/src/seismometer/data/filter.py
+++ b/src/seismometer/data/filter.py
@@ -373,7 +373,8 @@ def filter_rule_from_cohort_dictionary(cohort:dict[str, tuple[any]] | None = Non
     Parameters
     ----------
     cohort : dict[str,tuplep[any]], optional
-        A dictionary of column names and cohort category labels, by default None, in which case an empty FilterRule is returned.
+        A dictionary of column names and cohort category labels, 
+        by default None, in which case FilterRule.all() is returned.
 
     Returns
     -------

--- a/src/seismometer/data/filter.py
+++ b/src/seismometer/data/filter.py
@@ -76,9 +76,7 @@ class FilterRule(object):
             )
 
         if relation in ["all", "none"] and (right is not None or left is not None):
-            raise TypeError(
-                f"Universal relation '{relation}' does not accept left/right items"
-            )
+            raise TypeError(f"Universal relation '{relation}' does not accept left/right items")
 
         if relation in ["and", "or"]:
             if not isinstance(left, FilterRule):
@@ -117,11 +115,11 @@ class FilterRule(object):
         if not isinstance(self.right, str):
             return f"FilterRule('{self.left}', '{self.relation}', {self.right})"
         return f"FilterRule('{self.left}', '{self.relation}', '{self.right}')"
-    
+
     def __str__(self) -> str:
         """
         User readable string that represents a FilterRule.
-        
+
         >>> rule1 = FilterRule("Val", ">=", 20)
         >>> rule2 = FilterRule("T/F", "==", 0)
         >>> rule3 = FilterRule("Other", "<", 5)
@@ -160,7 +158,7 @@ class FilterRule(object):
                     return f"{left} and {right}"
                 else:  # The "or" case
                     return f"{left} or {right}"
-            case _: # relation is checked in __init__, this should never be reached
+            case _:  # relation is checked in __init__, this should never be reached
                 raise ValueError(f"Unknown relation {self.relation}")
 
     def filter(self, data: pd.DataFrame) -> pd.DataFrame:
@@ -205,14 +203,14 @@ class FilterRule(object):
             return left
         if ~left == right:
             return FilterRule.all()
-        
+
         if left.relation == "all" or right.relation == "all":
             return FilterRule.all()
         if left.relation == "none":
             return right
         if right.relation == "none":
             return left
-        
+
         return FilterRule(left, "or", right)
 
     def __and__(left, right) -> "FilterRule":
@@ -220,14 +218,14 @@ class FilterRule(object):
             return left
         if ~left == right:
             return FilterRule.none()
-        
+
         if left.relation == "none" or right.relation == "none":
             return FilterRule.none()
         if left.relation == "all":
             return right
         if right.relation == "all":
             return left
-        
+
         return FilterRule(left, "and", right)
 
     def __invert__(self) -> "FilterRule":
@@ -348,32 +346,30 @@ class FilterRule(object):
         FilterRule where the column contains a value different from the key value.
         """
         return cls(column, "!=", value)
-    
+
     @classmethod
     def all(cls):
         """
         FilterRule that selects all rows.
         """
         return cls(None, "all")
-    
+
     @classmethod
     def none(cls):
         """
         FilterRule that selects no rows.
         """
         return cls(None, "none")
-    
 
 
-
-def filter_rule_from_cohort_dictionary(cohort:dict[str, tuple[any]] | None = None) -> FilterRule:
+def filter_rule_from_cohort_dictionary(cohort: dict[str, tuple[any]] | None = None) -> FilterRule:
     """
     For a given dictionary, generate a matching FilterRule
 
     Parameters
     ----------
     cohort : dict[str,tuplep[any]], optional
-        A dictionary of column names and cohort category labels, 
+        A dictionary of column names and cohort category labels,
         by default None, in which case FilterRule.all() is returned.
 
     Returns
@@ -385,7 +381,7 @@ def filter_rule_from_cohort_dictionary(cohort:dict[str, tuple[any]] | None = Non
     rule = FilterRule.all()
     if not cohort:
         return rule
-    
+
     for key in cohort:
         if not cohort[key]:
             continue

--- a/src/seismometer/data/filter.py
+++ b/src/seismometer/data/filter.py
@@ -12,7 +12,7 @@ class FilterRule(object):
     """
 
     MIN_ROWS: Optional[int] = 10
-    left: Union["FilterRule", str]
+    left: Union["FilterRule", str, None]
     relation: str
     right: Any
 

--- a/tests/data/test_filters.py
+++ b/tests/data/test_filters.py
@@ -33,7 +33,7 @@ class TestFilterRules:
 
     def test_filter_universal_rule_equals(self, test_dataframe):
         FilterRule.MIN_ROWS = None
-        pd.testing.assert_frame_equal(FilterRule.all().filter(test_dataframe),test_dataframe)
+        pd.testing.assert_frame_equal(FilterRule.all().filter(test_dataframe), test_dataframe)
         assert len(FilterRule.none().filter(test_dataframe)) == 0
         assert all(FilterRule.none().filter(test_dataframe).columns == test_dataframe.columns)
 
@@ -120,30 +120,30 @@ class TestFilterRules:
             FilterRule("ShouldBeNone", "all", None)
 
     def test_universal_idenpotence(self):
-        assert (FilterRule.all()  | FilterRule.none()) == FilterRule.all()
-        assert (FilterRule.none() | FilterRule.all())  == FilterRule.all()
-        assert (FilterRule.none() & FilterRule.all())  == FilterRule.none()
-        assert (FilterRule.all()  & FilterRule.none()) == FilterRule.none()
+        assert (FilterRule.all() | FilterRule.none()) == FilterRule.all()
+        assert (FilterRule.none() | FilterRule.all()) == FilterRule.all()
+        assert (FilterRule.none() & FilterRule.all()) == FilterRule.none()
+        assert (FilterRule.all() & FilterRule.none()) == FilterRule.none()
 
     def test_universal_conjunction(self):
         assert (FilterRule.none() & FilterRule.eq("Column", "Value")) == FilterRule.none()
-        assert (FilterRule.all()  & FilterRule.eq("Column", "Value")) == FilterRule.eq("Column", "Value")
+        assert (FilterRule.all() & FilterRule.eq("Column", "Value")) == FilterRule.eq("Column", "Value")
 
         assert (FilterRule.eq("Column", "Value") & FilterRule.none()) == FilterRule.none()
-        assert (FilterRule.eq("Column", "Value") & FilterRule.all())  == FilterRule.eq("Column", "Value")
+        assert (FilterRule.eq("Column", "Value") & FilterRule.all()) == FilterRule.eq("Column", "Value")
 
     def test_universal_disjunction(self):
         assert (FilterRule.none() | FilterRule.eq("Column", "Value")) == FilterRule.eq("Column", "Value")
-        assert (FilterRule.all()  | FilterRule.eq("Column", "Value")) == FilterRule.all()
+        assert (FilterRule.all() | FilterRule.eq("Column", "Value")) == FilterRule.all()
         # reverse order
         assert (FilterRule.eq("Column", "Value") | FilterRule.none()) == FilterRule.eq("Column", "Value")
-        assert (FilterRule.eq("Column", "Value") | FilterRule.all())  == FilterRule.all()
+        assert (FilterRule.eq("Column", "Value") | FilterRule.all()) == FilterRule.all()
 
     def test_conjuction_idenpotence(self):
         rule1 = FilterRule("Val", ">=", 20)
         assert rule1 == rule1 & rule1
         assert rule1 == rule1 | rule1
-    
+
     def test_disjunction_idenpotence(self):
         rule1 = FilterRule("Val", ">=", 20)
         assert rule1 == rule1 | rule1
@@ -160,7 +160,6 @@ class TestFilterRules:
         rule2 = FilterRule("T/F", "==", 0)
         rule3 = rule1 | rule2
         assert rule3.mask(test_dataframe).equals((rule1.mask(test_dataframe) | rule2.mask(test_dataframe)))
-
 
     def test_negation_logic(self):
         assert FilterRule("Val", ">=", 20) == ~FilterRule("Val", "<", 20)
@@ -207,13 +206,12 @@ class TestFilterRules:
 
 
 class TestFilterRuleDisplay:
-    
     def test_repr_universal(self):
         assert repr(FilterRule.all()) == "FilterRule.all()"
         assert repr(FilterRule.none()) == "FilterRule.none()"
         assert repr(FilterRule(None, "all", None)) == "FilterRule.all()"
         assert repr(FilterRule(None, "none", None)) == "FilterRule.none()"
-        
+
     def test_str_universal(self):
         assert str(FilterRule.all()) == "Include all"
         assert str(FilterRule.none()) == "Exclude all"
@@ -227,7 +225,7 @@ class TestFilterRuleDisplay:
     def test_str_unary(self):
         assert str(FilterRule.isna("cat")) == "cat is missing"
         assert str(FilterRule.notna("cat")) == "cat has a value"
-    
+
     def test_repr_binary(self):
         assert repr(FilterRule("Val", ">=", 20)) == "FilterRule('Val', '>=', 20)"
         assert repr(FilterRule("Cat", "!=", "A")) == "FilterRule('Cat', '!=', 'A')"


### PR DESCRIPTION
# Overview
In order to build a filter rule from scratch, we should have universal quantifiers so that we can start with FilterRule.all(), and using and/or to build out more complex logic. 

We should also have a nicer string format separate from the repr string so that we can potentially display the filter rule used in a User readable format. 

## Description of changes

- Added `FilterRule.all()` and `FilterRule.none()` class methods that create the universal quantifier rules.
- Added a new `__str__` method with nicer strings
- Updated `filter_rule_from_cohort_dictionary` to allow starting from None by using FilterRule.all() as a base. 
- Updated unit tests for filters

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
