### PR TITLE
Create hook for post_load data transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,7 @@ ENV/
 
 
 # Repository development directories
-.Trash-1000/*
+.Trash-1000/
 /resources/
 /secrets/
 /secret/

--- a/changelog/56.feature.rst
+++ b/changelog/56.feature.rst
@@ -1,1 +1,2 @@
-Updates the loading pipeline to have a hook for updating the loaded dataframe.  Not accessible via run_startup(), requires direct initialization of Seismogram.
+- Updates the Seismogram class constructor to take precisely a DataLoader and a ConfigProvider, improving separation between the class and configuration loading.
+- Adds a post-load hook for modifying the otherwise ready dataframe.  This hook is not accessible via normal run_startup, and requires direct initialization of Seismogram.

--- a/changelog/56.feature.rst
+++ b/changelog/56.feature.rst
@@ -1,0 +1,1 @@
+Updates the loading pipeline to have a hook for updating the loaded dataframe.  Not accessible via run_startup(), requires direct initialization of Seismogram.

--- a/docs/reference/seismogram.rst
+++ b/docs/reference/seismogram.rst
@@ -19,7 +19,6 @@ Initialization
    :toctree: api/
 
    Seismogram.create_cohorts
-   Seismogram.load_config
    Seismogram.load_data
 
 Properties and Accessors

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -506,7 +506,7 @@ the model's name and any configured thresholds. It is typically defined in a
 Modifying the Analysis Data
 ---------------------------
 
-When possible it can be better to modify the data during extraction and have predictions and events files contain everything that is needed for analysis.
+When possible it is better to supplement the data upstream from seismometer such as during data extraction and have predictions and events files contain everything that is needed for analysis.
 However, there will inevitably be times when this is not possible but you still want transformations to be done prior to most of the notebook running.
 
 In this situation, you should modify the first cell of your notebook to run a custom startup method instead of ``run_startup``.
@@ -519,7 +519,7 @@ Then, follow the pattern of normal startup but specify your function in the :py:
    from seismometer.configuration import ConfigProvider
    from seismometer.data.loader import loader_factory
    from seismometer.seismogram import Seismogram
-
+   import seismometer._api as sm
    def my_startup(config_path="."):
       config = ConfigProvider(config_path)
       loader = loader_factory(config, post_load_fn=custom_post_load_fn)

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -506,8 +506,8 @@ the model's name and any configured thresholds. It is typically defined in a
 Modifying the Analysis Data
 ---------------------------
 
-When possible it is better to supplement the data upstream from seismometer such as during data extraction and have predictions and events files contain everything that is needed for analysis.
-However, there will inevitably be times when this is not possible but you still want transformations to be done prior to most of the notebook running.
+When possible it is better to supplement the data upstream from seismometer, such as during data extraction, and have predictions and events files contain everything that is needed for analysis.
+Inevitably, there will be times when this is not possible and you need additional transformations to be done prior to most of the notebook running.
 
 In this situation, you should modify the first cell of your notebook to run a custom startup method instead of ``run_startup``.
 The general outline of what the code should do is the same but will take advantage of the post_load_fn hook.
@@ -520,6 +520,11 @@ Then, follow the pattern of normal startup but specify your function in the :py:
    from seismometer.data.loader import loader_factory
    from seismometer.seismogram import Seismogram
    import seismometer._api as sm
+
+   def custom_post_load_fn(config: ConfigProvider, df: pd.DataFrame) -> pd.DataFrame:
+      df["SameAB"] = df["A"] == df["B"]
+      return df
+
    def my_startup(config_path="."):
       config = ConfigProvider(config_path)
       loader = loader_factory(config, post_load_fn=custom_post_load_fn)

--- a/src/seismometer/__init__.py
+++ b/src/seismometer/__init__.py
@@ -44,6 +44,8 @@ def run_startup(
     """
     import importlib
 
+    from seismometer.configuration import ConfigProvider
+    from seismometer.data.loader import loader_factory
     from seismometer.seismogram import Seismogram
 
     set_default_logger_config()
@@ -56,7 +58,10 @@ def run_startup(
 
     if reset:
         Seismogram.kill()
-    sg = Seismogram(config_path, output_path, definitions=definitions)
+
+    config = ConfigProvider(config_path, output_path, definitions=definitions)
+    loader = loader_factory(config)
+    sg = Seismogram(config, loader)
     sg.load_data(predictions=predictions_frame, events=events_frame)
 
     # Surface api into namespace

--- a/src/seismometer/__init__.py
+++ b/src/seismometer/__init__.py
@@ -59,7 +59,7 @@ def run_startup(
     if reset:
         Seismogram.kill()
 
-    config = ConfigProvider(config_path, output_path, definitions=definitions)
+    config = ConfigProvider(config_path, output_path=output_path, definitions=definitions)
     loader = loader_factory(config)
     sg = Seismogram(config, loader)
     sg.load_data(predictions=predictions_frame, events=events_frame)

--- a/src/seismometer/configuration/config.py
+++ b/src/seismometer/configuration/config.py
@@ -39,17 +39,21 @@ class ConfigProvider:
         This is the template that will be used as a base for building the final notebook.
     definitions : Optional[dict], optional
         A dictionary of definitions to use instead of loading those specified by configuration, by default None.
-
+    output_path : Optional[str | Path], optional
+        Used by the builder CLI, specifies the path to the output directory or file, by default None;
+        if a directory, the template notebook will be used with a "gen_" prefix.
     """
 
     def __init__(
         self,
         config_config: str | Path,
+        *,
         usage_config: str | Path = None,
         info_dir: str | Path = None,
         data_dir: str | Path = None,
         template_notebook: Option = None,
         definitions: dict = None,
+        output_path: str | Path = None,
     ):
         self._config: OtherInfo = None
         self._usage: DataUsage = None
@@ -63,7 +67,7 @@ class ConfigProvider:
             self._event_defs = EventDictionary(events=definitions.pop("events", None))
 
         self._load_config_config(config_config)
-        self._resolve_other_paths(usage_config, info_dir, data_dir)
+        self._resolve_other_paths(usage_config, info_dir, data_dir, output_path)
         self._override_template(template_notebook)
 
     def _override_template(self, template_notebook: Option) -> None:
@@ -78,7 +82,8 @@ class ConfigProvider:
         """
         Loads the configuration file containing "other_info".
         """
-        config_path = Path(config_config)
+        config_path = Path.cwd() / "data" if config_config is None else Path(config_config)
+
         if config_path.is_dir():
             self.config_dir: Path = config_path
             self.config_file: str = "config.yml"
@@ -91,7 +96,11 @@ class ConfigProvider:
         self.config = OtherInfo(**raw_config["other_info"])
 
     def _resolve_other_paths(
-        self, usage_config: str | Path = None, info_dir: str | Path = None, data_dir: str | Path = None
+        self,
+        usage_config: str | Path = None,
+        info_dir: str | Path = None,
+        data_dir: str | Path = None,
+        output_path: str | Path = None,
     ) -> None:
         """
         Identifies the paths to all other configuration between primary configuration and specified values.
@@ -100,6 +109,7 @@ class ConfigProvider:
         self.config.usage_config = Path(usage_config) if usage_config is not None else Path(self.config.usage_config)
         self.config.info_dir = Path(info_dir) if info_dir is not None else Path(self.config.info_dir)
         self.config.data_dir = Path(data_dir) if data_dir is not None else Path(self.config.data_dir)
+        self.set_output(output_path)
 
     # region Config
     @property
@@ -408,6 +418,8 @@ class ConfigProvider:
         """The directory for output files."""
         if self._output_dir is None:
             self._output_dir = Path.cwd()
+        # Make directory on first access
+        self._output_dir.mkdir(exist_ok=True, parents=True)
         return Path(self._output_dir)
 
     @property

--- a/src/seismometer/configuration/config.py
+++ b/src/seismometer/configuration/config.py
@@ -41,7 +41,7 @@ class ConfigProvider:
         A dictionary of definitions to use instead of loading those specified by configuration, by default None.
     output_path : Optional[str | Path], optional
         Used by the builder CLI, specifies the path to the output directory or file, by default None;
-        if a directory, the template notebook will be used with a "gen_" prefix.
+        if a directory, the template notebook will be used with the prefix gen.
     """
 
     def __init__(

--- a/src/seismometer/data/loader/__init__.py
+++ b/src/seismometer/data/loader/__init__.py
@@ -5,7 +5,7 @@ from seismometer.configuration import ConfigProvider
 from .pipeline import ConfigFrameHook, ConfigOnlyHook, MergeFramesHook, SeismogramLoader
 
 
-def loader_factory(config: ConfigProvider) -> SeismogramLoader:
+def loader_factory(config: ConfigProvider, post_load_fn: ConfigFrameHook = None) -> SeismogramLoader:
     """
     Construct a SeismogramLoader from the provided configuration.
 
@@ -13,6 +13,10 @@ def loader_factory(config: ConfigProvider) -> SeismogramLoader:
     ----------
     config : ConfigProvider
         The loaded configuration object
+    post_load_fn : ConfigFrameHook, optional
+        A callable taking a ConfigProvider and the fully loaded dataframe and returning a dataframe.
+        Used to allow any custom manipulations of the Seismogram dataframe after all other load steps complete.
+        WARNING: This can completly overwrite/discard the daframe that was loaded.
 
     Returns
     -------
@@ -29,4 +33,5 @@ def loader_factory(config: ConfigProvider) -> SeismogramLoader:
         event_fn=event_loader,
         post_event_fn=event.post_transform_fn,
         merge_fn=event.merge_onto_predictions,
+        post_load_fn=post_load_fn,
     )

--- a/src/seismometer/data/loader/pipeline.py
+++ b/src/seismometer/data/loader/pipeline.py
@@ -137,8 +137,6 @@ class SeismogramLoader:
         dataframe = self.post_predict_fn(self.config, dataframe)
         dataframe = self._add_events(dataframe, event_obj)
 
-        dataframe = self._add_custom_columns(dataframe)
-
         dataframe = self.post_load_fn(self.config, dataframe)
         return dataframe
 
@@ -172,14 +170,6 @@ class SeismogramLoader:
         if event_obj is None:
             return self.event_fn(self.config)
         return self.event_from_memory(self.config, event_obj)
-
-    def _add_custom_columns(self, dataframe: pd.DataFrame) -> pd.DataFrame:
-        """
-        Add custom columns to the dataframe based on configuration.
-
-        NotImplemented -- currently a pass-through.
-        """
-        return dataframe
 
 
 __all__ = ["SeismogramLoader", "ConfigOnlyHook", "ConfigFrameHook", "MergeFramesHook"]

--- a/src/seismometer/seismogram.py
+++ b/src/seismometer/seismogram.py
@@ -11,7 +11,7 @@ from seismometer.configuration import AggregationStrategies, ConfigProvider
 from seismometer.core.patterns import Singleton
 from seismometer.data import pandas_helpers as pdh
 from seismometer.data import resolve_cohorts
-from seismometer.data.loader import SeismogramLoader, loader_factory
+from seismometer.data.loader import SeismogramLoader
 from seismometer.report.alerting import AlertConfigProvider
 
 MAXIMUM_NUM_COHORTS = 25
@@ -50,10 +50,8 @@ class Seismogram(object, metaclass=Singleton):
 
     def __init__(
         self,
-        config_path: Optional[str | Path] = None,
-        output_path: Optional[str | Path] = None,
-        definitions: Optional[dict] = None,
-        loader: SeismogramLoader = None,
+        config: ConfigProvider,
+        dataloader: SeismogramLoader,
     ):
         """
         Constructor for Seismogram, which can only be instantiated once.
@@ -62,31 +60,19 @@ class Seismogram(object, metaclass=Singleton):
 
         Parameters
         ----------
-        config_path : str or Path, optional
-            Where to find the primary configuration file, defaults to the notebook's data directory.
-        output_path : str or Path, optional
-            Override location to place resulting data and report files.
-            Defaults to the config.yml info_dir, and then the notebook's output directory.
-        definitions : dict, optional
-            Additional definitions to be used instead of loading based on configuration, by default None.
-        loader : SeismogramLoader, optional
-            A loader instance for defining the data loading pipeline, by default None.
-            If not provided, uses factory to instantiate the loader based on configuration.
+        config : ConfigProvider
+            The configuration provider instance.
+        dataloader : SeismogramLoader, optional
+            A loader instance for defining the data loading pipeline.
+
         """
-        if config_path is None:
-            config_path = Path.cwd() / "data"
-        else:
-            config_path = Path(config_path)
+        self.config = config
+        self.dataloader = dataloader
 
         self.dataframe: pd.DataFrame = None
         self.cohort_cols: list[str] = []
-        self.config_path = config_path
 
-        self.load_config(config_path, definitions=definitions)
-
-        self.config.set_output(output_path)
-        self.config.output_dir.mkdir(parents=True, exist_ok=True)
-        self.dataloader = loader or loader_factory(self.config)
+        self.copy_config_metadata()
 
     def load_data(
         self, *, predictions: Optional[pd.DataFrame] = None, events: Optional[pd.DataFrame] = None, reset: bool = False
@@ -328,7 +314,7 @@ class Seismogram(object, metaclass=Singleton):
     # endregion
 
     # region initialization and preprocessing (this region knows about config)
-    def load_config(self, config_path: Path, definitions: Optional[dict] = None):
+    def copy_config_metadata(self):
         """
         Loads the base configuration and alerting congfiguration
 
@@ -340,8 +326,7 @@ class Seismogram(object, metaclass=Singleton):
             An optional dictionary containing both events and predictions lists, by default None.
             If not passed, these will be loaded based on configuration.
         """
-        self.config = ConfigProvider(config_path, definitions=definitions)
-        self.alert_config = AlertConfigProvider(config_path)
+        self.alert_config = AlertConfigProvider(self.config.config_path)
 
         if len(self.config.cohorts) == 0:
             logger.warning("No cohort columns were configured; tool may behave unexpectedly.")

--- a/src/seismometer/seismogram.py
+++ b/src/seismometer/seismogram.py
@@ -11,7 +11,7 @@ from seismometer.configuration import AggregationStrategies, ConfigProvider
 from seismometer.core.patterns import Singleton
 from seismometer.data import pandas_helpers as pdh
 from seismometer.data import resolve_cohorts
-from seismometer.data.loader import loader_factory
+from seismometer.data.loader import SeismogramLoader, loader_factory
 from seismometer.report.alerting import AlertConfigProvider
 
 MAXIMUM_NUM_COHORTS = 25
@@ -53,6 +53,7 @@ class Seismogram(object, metaclass=Singleton):
         config_path: Optional[str | Path] = None,
         output_path: Optional[str | Path] = None,
         definitions: Optional[dict] = None,
+        loader: SeismogramLoader = None,
     ):
         """
         Constructor for Seismogram, which can only be instantiated once.
@@ -68,7 +69,9 @@ class Seismogram(object, metaclass=Singleton):
             Defaults to the config.yml info_dir, and then the notebook's output directory.
         definitions : dict, optional
             Additional definitions to be used instead of loading based on configuration, by default None.
-
+        loader : SeismogramLoader, optional
+            A loader instance for defining the data loading pipeline, by default None.
+            If not provided, uses factory to instantiate the loader based on configuration.
         """
         if config_path is None:
             config_path = Path.cwd() / "data"
@@ -83,7 +86,7 @@ class Seismogram(object, metaclass=Singleton):
 
         self.config.set_output(output_path)
         self.config.output_dir.mkdir(parents=True, exist_ok=True)
-        self.dataloader = loader_factory(self.config)
+        self.dataloader = loader or loader_factory(self.config)
 
     def load_data(
         self, *, predictions: Optional[pd.DataFrame] = None, events: Optional[pd.DataFrame] = None, reset: bool = False

--- a/src/seismometer/seismogram.py
+++ b/src/seismometer/seismogram.py
@@ -1,7 +1,6 @@
 import json
 import logging
 from functools import lru_cache
-from pathlib import Path
 from typing import Optional
 
 import numpy as np
@@ -43,8 +42,6 @@ class Seismogram(object, metaclass=Singleton):
     """ The one or two columns used as identifiers for data. """
     predict_time: str
     """ The column name for evaluation timestamp. """
-    config_path: Path
-    """ The location of the main configuration file. """
     output_list: list[str]
     """ The list of columns representing model outputs."""
 
@@ -317,16 +314,8 @@ class Seismogram(object, metaclass=Singleton):
     def copy_config_metadata(self):
         """
         Loads the base configuration and alerting congfiguration
-
-        Parameters
-        ----------
-        config_path : Path
-            The location of the main configuration file.
-        definitions : Optional[dict], optional
-            An optional dictionary containing both events and predictions lists, by default None.
-            If not passed, these will be loaded based on configuration.
         """
-        self.alert_config = AlertConfigProvider(self.config.config_path)
+        self.alert_config = AlertConfigProvider(self.config.config_dir)
 
         if len(self.config.cohorts) == 0:
             logger.warning("No cohort columns were configured; tool may behave unexpectedly.")

--- a/tests/configuration/test_provider.py
+++ b/tests/configuration/test_provider.py
@@ -9,6 +9,8 @@ import seismometer.configuration.config as undertest
 BUILDER_CONFIG = _files(seismometer.builder.resources) / "config.yml"
 
 
+# Could share temp directory across all tests
+@pytest.mark.usefixtures("tmp_as_current")
 class TestConfigProvider:
     def test_builder_default_template_is_binary(self):
         config = undertest.ConfigProvider(BUILDER_CONFIG)
@@ -35,8 +37,7 @@ class TestConfigProvider:
             ("interventions", {}),
             ("prediction_columns", ["Age", "Input", "Score", "ScoringTime", "encounter_id", "id"]),
             ("censor_min_count", 15),
-            ("output_dir", Path.cwd()),
-            ("output_notebook", ""),
+            ("output_notebook", "classifier_bin.ipynb"),
         ],
     )
     def test_build_config_is_valid_simple_object(self, property, value):
@@ -44,3 +45,7 @@ class TestConfigProvider:
         actual = getattr(config, property)
 
         assert actual == value
+
+    def test_build_config_uses_tmp(self, tmp_path):
+        config = undertest.ConfigProvider(BUILDER_CONFIG)
+        assert config.output_dir == tmp_path / "outputs"

--- a/tests/test_seismogram.py
+++ b/tests/test_seismogram.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest.mock import Mock
 
 import pandas as pd
@@ -23,7 +22,7 @@ def get_test_config(tmp_path):
     mock_config.predict_time = "time"
     mock_config.cohorts = ["cohort1", "cohort2", "cohort3"]
     mock_config.features = ["one"]
-    mock_config.config_path = Path(tmp_path / "config")
+    mock_config.config_dir = tmp_path / "config"
 
     return mock_config
 


### PR DESCRIPTION
# Overview
Added a hook to DataLoader (and loader_factory) to accept a ConfigFrameHook function; allowing modification of the Seismogram dataframe 'during' load.  
This necessitated improving the separation of config and Seismogram, slimming the constructor of the latter and moving a couple configuration manipulations to ConfigProvider

## Review focus
- [ ] verify existing example notebooks work without modification
- [ ] use the new documentation (under userguide) to create a custom function and instantiate a Seismogram using it


## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
