### PR TITLE
Censor Leadtime and Cohort plots rather than raising errors + UX Fixes

### DIFF
--- a/src/seismometer/_api.py
+++ b/src/seismometer/_api.py
@@ -16,6 +16,7 @@ from .controls.explore import (
     ExplorationWidget,
     ModelFairnessAuditOptions,
 )
+from .core.exceptions import CensoredResultException
 from .core.io import slugify
 from .data import (
     assert_valid_performance_metrics_df,
@@ -263,9 +264,12 @@ def generate_fairness_audit(
     data = FilterRule.isin(target, (0, 1)).filter(data)
     if len(data.index) < sg.censor_threshold:
         return template.render_censored_plot_message(sg.censor_threshold)
-    fairness_audit_to_html(
-        fairness_path, data, cohort_columns, score_column, target, score_threshold, metric_list, fairness_threshold
-    )
+    try:
+        fairness_audit_to_html(
+            fairness_path, data, cohort_columns, score_column, target, score_threshold, metric_list, fairness_threshold
+        )
+    except CensoredResultException as error:
+        return template.render_censored_data_message(error.message)
     return load_as_iframe(fairness_path, height=height)
 
 
@@ -613,7 +617,11 @@ def _plot_leadtime_enc(
         score=score,
         ref_event=target_zero,
         aggregation_method="first",
-    )[[target_zero, ref_time, cohort_col]]
+    )
+    if summary_data is not None and len(summary_data) > censor_threshold:
+        summary_data = summary_data[[target_zero, ref_time, cohort_col]]
+    else:
+        return template.render_censored_plot_message(censor_threshold)
 
     # filter by group size
     counts = summary_data[cohort_col].value_counts()

--- a/src/seismometer/controls/cohort_comparison.py
+++ b/src/seismometer/controls/cohort_comparison.py
@@ -8,7 +8,7 @@ from ipywidgets import Box, Button, Output, VBox
 from seismometer.data.filter import filter_rule_from_cohort_dictionary
 
 from .selection import MultiSelectionListWidget
-from .styles import BOX_GRID_LAYOUT
+from .styles import BOX_GRID_LAYOUT, WIDE_BUTTON_LAYOUT
 
 logger = logging.getLogger("seismometer")
 
@@ -27,7 +27,7 @@ class ComparisonReportGenerator:
             self.selectors.append(widget)
 
         self.output = Output()
-        self.button = Button(description=GENERATE_REPORT, button_style="primary")
+        self.button = Button(description=GENERATE_REPORT, button_style="primary", layout=WIDE_BUTTON_LAYOUT)
         self.button.on_click(partial(self._generate_comparison_report, self))
 
     def show(self):

--- a/src/seismometer/controls/explore.py
+++ b/src/seismometer/controls/explore.py
@@ -7,7 +7,7 @@ from IPython.display import display
 from ipywidgets import HTML, Box, Button, Checkbox, Dropdown, FloatSlider, Layout, Output, ValueWidget, VBox
 
 from .selection import DisjointSelectionListsWidget, MultiSelectionListWidget, SelectionListWidget
-from .styles import BOX_GRID_LAYOUT, WIDE_LABEL_STYLE
+from .styles import BOX_GRID_LAYOUT, WIDE_LABEL_STYLE, html_title
 from .thresholds import MonotonicProbabilitySliderListWidget
 
 logger = logging.getLogger("seismometer")
@@ -91,7 +91,7 @@ class ModelOptionsWidget(VBox, ValueWidget):
         per_context : bool, optional
             if scores should be grouped by context, by default None, in which case this checkbox is not shown.
         """
-        self.title = HTML('<h4 style="text-align: left; margin: 0px;">Model Options</h4>')
+        self.title = html_title("Model Options")
         self.target_list = Dropdown(
             options=target_names,
             value=target_names[0],
@@ -364,7 +364,7 @@ class ModelInterventionOptionsWidget(VBox, ValueWidget):
         reference_time_names : tuple[Any], optional
             name for the reference time to align patients, by default None
         """
-        self.title = HTML('<h4 style="text-align: left; margin: 0px;">Model Options</h4>')
+        self.title = html_title("Model Options")
         self.outcome_list = Dropdown(options=outcome_names, value=outcome_names[0], description="Outcome")
         self.intervention_list = Dropdown(
             options=intervention_names, value=intervention_names[0], description="Intervention"

--- a/src/seismometer/controls/selection.py
+++ b/src/seismometer/controls/selection.py
@@ -4,6 +4,8 @@ from typing import Optional
 import traitlets
 from ipywidgets import HTML, Box, Dropdown, Label, Layout, Stack, ToggleButton, ValueWidget, VBox, jslink
 
+from .styles import html_title
+
 
 class SelectionListWidget(ValueWidget, VBox):
     """
@@ -190,7 +192,7 @@ class MultiSelectionListWidget(ValueWidget, VBox):
 
     def update_title_section(self, title):
         if title:
-            self.title_box.value = f'<h4 style="text-align: left;  margin: 0px;">{title}</h4>'
+            self.title_box.value = html_title(title).value
 
 
 class DisjointSelectionListsWidget(ValueWidget, VBox):
@@ -226,7 +228,7 @@ class DisjointSelectionListsWidget(ValueWidget, VBox):
         """
         super().__init__()
         self.title = title
-        self.label = Label(title)
+        self.title_box = html_title(title)
 
         # preselect all values if select_all is set, will override with values next
         values = {k: options[k] if select_all else () for k in options}
@@ -252,7 +254,7 @@ class DisjointSelectionListsWidget(ValueWidget, VBox):
             self.selection_widgets[key] = selection_widget
             selection_widget.observe(self._on_selection_change, "value")
         self.stack = Stack(children=[self.selection_widgets[key] for key in self.selection_widgets], selected_index=0)
-        self.children = [self.label, self.dropdown, self.stack]
+        self.children = [self.title_box, self.dropdown, self.stack]
         jslink((self.dropdown, "index"), (self.stack, "selected_index"))
         self.layout = Layout(width="calc(100% - var(--jp-widgets-border-width)* 2)")
         self._on_selection_change()
@@ -284,5 +286,5 @@ class DisjointSelectionListsWidget(ValueWidget, VBox):
 
     def get_selection_text(self) -> str:
         """Return the selection for the widget as a key value pair."""
-        key, value = self.value
+        key = self.value[0]
         return f"{key}: {self.selection_widgets[key].get_selection_text()}"

--- a/src/seismometer/controls/styles.py
+++ b/src/seismometer/controls/styles.py
@@ -1,5 +1,11 @@
-from ipywidgets.widgets import Layout
+from ipywidgets.widgets import HTML, Layout
 
 WIDE_LABEL_STYLE = {"description_width": "120px"}
 
 BOX_GRID_LAYOUT = Layout(align_items="flex-start", grid_gap="20px", width="max-content", min_width="300px")
+WIDE_BUTTON_LAYOUT = Layout(align_items="flex-start", width="max-content", min_width="200px")
+
+
+def html_title(title: str) -> HTML:
+    """html title style"""
+    return HTML(f'<h4 style="text-align: left;  margin: 0px;">{title}</h4>')

--- a/src/seismometer/core/exceptions.py
+++ b/src/seismometer/core/exceptions.py
@@ -1,0 +1,2 @@
+class CensoredResultException(Exception):
+    pass

--- a/src/seismometer/html/template.py
+++ b/src/seismometer/html/template.py
@@ -104,7 +104,24 @@ def render_censored_plot_message(censor_threshold: int) -> HTML:
     HTML
         The templated HTML.
     """
-    return render_title_message("Data is censored.", f"There are {censor_threshold} or fewer rows.")
+    return render_censored_data_message(f"There are {censor_threshold} or fewer rows.")
+
+
+def render_censored_data_message(message: str) -> HTML:
+    """
+    Get templated HTML containing a censored data message.
+
+    Parameters
+    ----------
+    message : str
+        The message to display.
+
+    Returns
+    -------
+    HTML
+        The templated HTML.
+    """
+    return render_title_message("Data is censored.", message)
 
 
 def render_title_with_image(title: str, image: SVG) -> HTML:

--- a/src/seismometer/report/auditing.py
+++ b/src/seismometer/report/auditing.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pandas as pd
 
+from ..core.exceptions import CensoredResultException
+
 logger = logging.getLogger("seismometer")
 
 allowed_metrics = ["tpr", "tnr", "for", "fdr", "fpr", "fnr", "npv", "ppr", "precision", "pprev"]
@@ -74,8 +76,7 @@ def fairness_audit_to_html(
     df.drop(score_column, axis=1, inplace=True)
 
     if df["score"].nunique() != 2:
-        logger.error("Audit requires exactly two target classes to be present")
-        return
+        raise CensoredResultException("Audit requires exactly two target classes to be present")
 
     # Do NOT pass list of sensitive attributes; reducing frame gets desired behavior
     audit = Audit(df, score_column="score", label_column=target_column)

--- a/tests/html/test_templates.py
+++ b/tests/html/test_templates.py
@@ -84,10 +84,15 @@ class Test_Templates:
         assert "A Title" in html_source
         assert "The Message" in html_source
 
-    def test_censored_data_template(self):
+    def test_censored_plot_template(self):
         html_source = undertest.render_censored_plot_message(3).data
         assert "censored" in html_source
         assert "There are 3 or fewer rows." in html_source
+
+    def test_censored_data_template(self):
+        html_source = undertest.render_censored_data_message(Exception("Somthing Bad Happened")).data
+        assert "censored" in html_source
+        assert "Somthing Bad Happened" in html_source
 
     def test_title_image_template(self):
         svg_data = """


### PR DESCRIPTION
Add cohort censor message for high threshold values. 

1. Generate Report button larger in Cohort comparison report to fit text
2. Titles in Exploration controls matched to <h4> so they can pick up theme colors/css
3. Added a new exceptions class to seismometer.core.exceptions to enable reuse in future plots

# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->
Closes #xxx 

## Description of changes
<!-- Describe your changes and any implementation decisions -->
<!-- Especially for enhancements, start conversations early. Ideally in the documenting issue -->
<!-- Can be formatted as a checklist for reviewers. -->

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
