### PR TITLE
Increase robustness for cohorts

### DIFF
--- a/changelog/65.bugfix.rst
+++ b/changelog/65.bugfix.rst
@@ -1,0 +1,1 @@
+Warning message on censored cohorts is coerced to string before logging.

--- a/changelog/67.bugfix.rst
+++ b/changelog/67.bugfix.rst
@@ -1,0 +1,1 @@
+Log a warning if cohort source column is not found in the dataframe.

--- a/src/seismometer/seismogram.py
+++ b/src/seismometer/seismogram.py
@@ -373,7 +373,7 @@ class Seismogram(object, metaclass=Singleton):
                 continue
             if not sufficient.all():
                 log_details = ", ".join(sufficient[~sufficient].index.astype(str))
-                logger.debug(f"Some cohorts of {disp_attr} were below censor limit: {log_details}")
+                logger.warning(f"Some cohorts of {disp_attr} were below censor limit: {log_details}")
 
             self.dataframe[disp_attr] = new_col.cat.set_categories(sufficient[sufficient].index.tolist(), ordered=True)
             self.cohort_cols.append(disp_attr)

--- a/src/seismometer/seismogram.py
+++ b/src/seismometer/seismogram.py
@@ -346,6 +346,10 @@ class Seismogram(object, metaclass=Singleton):
         """Creates data columns for each cohort defined in configuration."""
         for cohort in self.config.cohorts:
             disp_attr = cohort.display_name
+
+            if cohort.source not in self.dataframe:
+                logger.warning(f"Source column {cohort.source} not found in data; skipping cohort {disp_attr}.")
+                continue
             if cohort.splits:
                 try:
                     new_col = resolve_cohorts(self.dataframe[cohort.source], cohort.splits)
@@ -368,9 +372,8 @@ class Seismogram(object, metaclass=Singleton):
                 )
                 continue
             if not sufficient.all():
-                logger.debug(
-                    f"Some cohorts of {disp_attr} were below censor limit: {', '.join(sufficient[~sufficient].index)}"
-                )
+                log_details = ", ".join(sufficient[~sufficient].index.astype(str))
+                logger.debug(f"Some cohorts of {disp_attr} were below censor limit: {log_details}")
 
             self.dataframe[disp_attr] = new_col.cat.set_categories(sufficient[sufficient].index.tolist(), ordered=True)
             self.cohort_cols.append(disp_attr)


### PR DESCRIPTION
# Overview
Closes #65, #67, #69

## Description of changes
Convert censored cohort values to string, to be printable in warnings.  
Check if cohort sources exist before trying to load.  While this was originally expected to be a configuration update, robustness here accounts for data extraction that drops empty columns.

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
