### PR TITLE
fix side scrolling when there are many cohort features. 

### DIFF
--- a/src/seismometer/_api.py
+++ b/src/seismometer/_api.py
@@ -243,7 +243,7 @@ def generate_fairness_audit(
     if per_context:
         path += "_grouped"
     fairness_path = sg.config.output_dir / (slugify(path) + ".html")
-    height = 100 + 100 * len(metric_list)
+    height = 200 + 100 * len(metric_list)
 
     if NotebookHost.supports_iframe() and fairness_path.exists():
         return load_as_iframe(fairness_path, height=height)

--- a/src/seismometer/controls/styles.py
+++ b/src/seismometer/controls/styles.py
@@ -2,7 +2,9 @@ from ipywidgets.widgets import HTML, Layout
 
 WIDE_LABEL_STYLE = {"description_width": "120px"}
 
-BOX_GRID_LAYOUT = Layout(align_items="flex-start", grid_gap="20px", width="max-content", min_width="300px")
+BOX_GRID_LAYOUT = Layout(
+    align_items="flex-start", grid_gap="20px", width="100%", min_width="300px", max_width="1400px"
+)
 WIDE_BUTTON_LAYOUT = Layout(align_items="flex-start", width="max-content", min_width="200px")
 
 


### PR DESCRIPTION
# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->
Closes #xxx 

## Description of changes
Cap the width of the cohort selector control to prevent side scrolling, allow wrapping to enable multiple rows of cohort selection controls. 
Add a bit of height to the audit control iframe to enable displaying errors for a cohort category. 

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
