### PR TITLE
Fix and simplify window merge

### DIFF
--- a/changelog/71.bugfix.rst
+++ b/changelog/71.bugfix.rst
@@ -1,0 +1,3 @@
+Handle merging without context id; assumes events dataframe columns.
+Remove coalecsing logic from merging, now assumes an event type always has times (or never does). Preps for supporting strategies.
+Hardens restriction of events (with times) to occur after prediction time + window offset.

--- a/changelog/71.bugfix.rst
+++ b/changelog/71.bugfix.rst
@@ -1,3 +1,1 @@
 Handle merging without context id; assumes events dataframe columns.
-Remove coalecsing logic from merging, now assumes an event type always has times (or never does). Preps for supporting strategies.
-Hardens restriction of events (with times) to occur after prediction time + window offset.

--- a/changelog/72.bugfix.rst
+++ b/changelog/72.bugfix.rst
@@ -1,2 +1,2 @@
-Simplify merge logic for the single 'first' strategy. This remove coalecsing logic by assumes an event type always has times (or never does).
+Simplify merge logic for the single 'first' strategy. This removes coalecsing logic by assuming an event type always has times (or never does).
 Hardens restriction of events (with times) to occur after prediction time + window offset, not having the unintuitive partial information for early, late, and unknown timings.

--- a/changelog/72.bugfix.rst
+++ b/changelog/72.bugfix.rst
@@ -1,0 +1,2 @@
+Simplify merge logic for the single 'first' strategy. This remove coalecsing logic by assumes an event type always has times (or never does).
+Hardens restriction of events (with times) to occur after prediction time + window offset, not having the unintuitive partial information for early, late, and unknown timings.

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -21,7 +21,7 @@ Jupyter Notebook templates
 --------------------------
 
 Open-source Python libraries and Jupyter Notebooks allow data scientists
-to quickly generate a notebook to evaluate model performance. 
+to quickly generate a notebook to evaluate model performance.
 
 We expect these templates to continually evolve as new validation and
 analysis techniques and approaches are created.
@@ -52,7 +52,7 @@ following at your command line:
 
    pip install seismometer
 
-If you want to utilize fairness audit visualizations, run the following at 
+If you want to utilize fairness audit visualizations, run the following at
 your command line:
 
 .. code-block:: bash
@@ -152,7 +152,8 @@ model output and expected measurable results driven by those actions.
 The configuration includes two core elements:
 
 1. Data definitions to map columns in your data tables to the keys used
-   in the Notebook template.
+   in the Notebook template. This includes information on how data is
+   used, including associating events to relevant predictions.
 
 2. Supplemental documentation to give report consumers working in the
    Notebook background on the model, definitions of terms and cohorts,

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -445,6 +445,8 @@ targets, interventions, and outcomes associated with an entity.
          value: Value
       # Events define what types of events to merge into analyses
       # Windowing defines the range of time prior to the event where predictions are considered
+      # On initial load, the events data are merged into a single frame alongside predictions, with
+      # those columns appearing empty if events only occur outside the window.
       events:
          - source: TargetLabel
            display_name: Readmitted within 30 Days
@@ -538,9 +540,9 @@ Among other things, this means any Seismograph notebooks cells do not have a dep
 Create Custom Visualizations
 ----------------------------
 
-You can create custom controls that allow users to interact with the data via a set of 
+You can create custom controls that allow users to interact with the data via a set of
 standardized controls. The :py:mod:`seismometer.controls.explore` module contains several ``Exploration*``
-widgets you can use for housing custom visualizations, see :ref:`custom-visualization-controls`. 
+widgets you can use for housing custom visualizations, see :ref:`custom-visualization-controls`.
 
 .. image:: media/custom_plot_control.png
    :alt: A custom control, allowing a user to select a cohort and display a heatmap restricted to that cohort.
@@ -551,21 +553,21 @@ it should return a displayable object. If using matplotlib, you can use the :py:
 decorator to convert the plot to an SVG, for the control to display.
 This will close the plot/figure after saving to prevent the plot from displaying twice.
 
-The following example shows how to create the visualization above. 
+The following example shows how to create the visualization above.
 
 .. code-block:: python
 
    import seaborn as sns
    import matplotlib.pyplot as plt
 
-   # Control allowing users to specify a score, target, threshold, and cohort. 
-   from seismometer.controls.explore import ExplorationModelSubgroupEvaluationWidget 
+   # Control allowing users to specify a score, target, threshold, and cohort.
+   from seismometer.controls.explore import ExplorationModelSubgroupEvaluationWidget
    # Converts matplotlib figure to SVG for display within the control's output
    from seismometer.plot.mpl.decorators import render_as_svg
-   # Filter our data based on a specified cohort 
-   from seismometer.data.filter import FilterRule 
+   # Filter our data based on a specified cohort
+   from seismometer.data.filter import FilterRule
 
-   
+
    @render_as_svg # convert figure to svg for display
    def plot_heat_map(
          cohort_dict: dict[str,tuple], # cohort columns and allowable values
@@ -583,7 +585,7 @@ The following example shows how to create the visualization above.
       sg = sm.Seismogram()
       cohort_filter = FilterRule.from_cohort_dictionary(cohort_dict) # Use only rows that match the cohort
       data = cohort_filter.filter(sg.data(target_col))
-      
+
       xcol = "age"
       ycol = "num_procedures"
       hue = score_col
@@ -598,9 +600,7 @@ The following example shows how to create the visualization above.
       plt.tight_layout()
       return plt.gcf()
 
-   ExplorationModelSubgroupEvaluationWidget("Heatmap", plot_heat_map) #generates the overall widget. 
+   ExplorationModelSubgroupEvaluationWidget("Heatmap", plot_heat_map) #generates the overall widget.
 
-The function ``plot_heat_map`` creates a heatmap of the mean of the score column for each subgroup of the cohort, based on 
-the fixed columns ``age`` and ``num_procedures``. 
-
-   
+The function ``plot_heat_map`` creates a heatmap of the mean of the score column for each subgroup of the cohort, based on
+the fixed columns ``age`` and ``num_procedures``.

--- a/src/seismometer/data/pandas_helpers.py
+++ b/src/seismometer/data/pandas_helpers.py
@@ -339,7 +339,7 @@ def _handle_merge(
     ct_times = one_event[event_ref].notna().sum()
     if ct_times == 0:
         logger.warning(f"No times found for {event_display}, merging first")
-        return pd.merge(predictions, one_event, how="left", on=pks)
+        return pd.merge(predictions, one_event.groupby(pks).first(), how="left", on=pks)
 
     if ct_times != len(one_event.index):
         warnings.warn(f"Inconsistent event times for {event_display}, only considering events with times.")

--- a/src/seismometer/data/pandas_helpers.py
+++ b/src/seismometer/data/pandas_helpers.py
@@ -339,7 +339,7 @@ def _handle_merge(
 
     ct_times = one_event[event_ref].notna().sum()
     if ct_times == 0:
-        logger.warning(f"No times found for {event_display}, merging first")
+        logger.warning(f"No times found for {event_display}, merging 'first'")
         return pd.merge(predictions, one_event.groupby(pks).first(), how="left", on=pks)
 
     if ct_times != len(one_event.index):

--- a/tests/data/loaders/test_load_events.py
+++ b/tests/data/loaders/test_load_events.py
@@ -123,7 +123,7 @@ class TestMergeOntoPredictions:
         )
 
         expected = predictions.copy()
-        expected[["a_Time", "a_Value"]] = event_df[["Time", "Value"]].values[[0, 2, 5]]
+        expected[["a_Value", "a_Time"]] = event_df[["Value", "Time"]].values[[0, 2, 5]]
         expected["a_Value"] = expected["a_Value"].astype(float)
 
         actual = undertest.merge_onto_predictions(config, event_df, predictions)
@@ -148,7 +148,7 @@ class TestMergeOntoPredictions:
         )
 
         expected = predictions.copy()
-        expected[["ac_Time", "ac_Value"]] = event_df[["Time", "Value"]].values[[0, 2, 5]]
+        expected[["ac_Value", "ac_Time"]] = event_df[["Value", "Time"]].values[[0, 2, 5]]
         expected["ac_Value"] = expected["ac_Value"].astype(float)
 
         actual = undertest.merge_onto_predictions(config, event_df, predictions)

--- a/tests/data/test_events.py
+++ b/tests/data/test_events.py
@@ -26,15 +26,15 @@ def event_data(res):
 class Test_Event_Score:
     @pytest.mark.parametrize("ref_event", ["Target", "PredictTime", "Reference_5_15_Time"])
     @pytest.mark.parametrize("aggregation_method", ["min", "max", "first", "last"])
-    @pytest.mark.parametrize("id_, csn", [pytest.param(1, 0, id="monotonic-increasing")])
-    def test_bad_event(self, id_, csn, aggregation_method, ref_event, event_data):
+    @pytest.mark.parametrize("id_, ctx", [pytest.param(1, 0, id="monotonic-increasing")])
+    def test_bad_event(self, id_, ctx, aggregation_method, ref_event, event_data):
         input_frame, expected_frame = event_data
         expected_score = expected_frame.loc[
             (expected_frame["Id"] == id_)
-            & (expected_frame["CSN"] == csn)
+            & (expected_frame["CtxId"] == ctx)
             & (expected_frame["ref_event"] == ref_event),
             aggregation_method,
         ]
 
-        actual = undertest.event_score(input_frame, ["Id", "CSN"], "ModelScore", ref_event, aggregation_method)
+        actual = undertest.event_score(input_frame, ["Id", "CtxId"], "ModelScore", ref_event, aggregation_method)
         assert actual["ModelScore"].tolist() == expected_score.tolist()

--- a/tests/data/test_merge_window.py
+++ b/tests/data/test_merge_window.py
@@ -17,7 +17,7 @@ def create_event_table(ids, ctxs, event_labels, event_offsets=None, event_values
     count = len(event_times)
     return pd.DataFrame(
         {
-            "Id": ids * count if len(ids) == 1 else ids,
+            "Id": [str(i) for i in (ids * count if len(ids) == 1 else ids)],
             "CtxId": ctxs * count if len(ctxs) == 1 else ctxs,
             "Type": event_labels,
             "Time": event_times,
@@ -30,7 +30,7 @@ def create_prediction_table(ids, ctxs, predtimes):
     count = len(predtimes)
     return pd.DataFrame(
         {
-            "Id": ids * count if len(ids) == 1 else ids,
+            "Id": [str(i) for i in (ids * count if len(ids) == 1 else ids)],
             "CtxId": ctxs * count if len(ctxs) == 1 else ctxs,
             "PredictTime": pd.to_datetime(predtimes),
         }
@@ -821,7 +821,7 @@ class TestMergeWindowedEvent:
 
     def test_no_times_warn_and_merges(self, caplog):
         # Use two ctxs
-        ids = np.repeat([1], 10)
+        ids = np.repeat([1], 10).astype("int64")
         ctxs = np.repeat([1, 2], 5)
         event_name = "TestEvent"
         predtimes = [

--- a/tests/data/test_merge_window.py
+++ b/tests/data/test_merge_window.py
@@ -78,7 +78,7 @@ class TestMergeWindowedEvent:
                 2, 2, None, "2024-02-01 12:00:00", 12, 0, "2024-02-01 12:00:00", 1, id="null in_window: impute+"
             ),
             #
-            # Predictions for positive labels after last event(late prediction) have label imputed to -1,
+            # Predictions for positive labels after last event(late prediction) are no time and imputed to negative,
             # but keep time
             pytest.param(
                 3,
@@ -87,9 +87,9 @@ class TestMergeWindowedEvent:
                 "2024-01-31 12:00:00",
                 12,
                 0,
-                "2024-01-31 12:00:00",
-                -1,
-                id="pos val late time: invalidate label",
+                None,
+                0,
+                id="pos val late time: NaT+0",
             ),
             pytest.param(
                 3,
@@ -98,9 +98,9 @@ class TestMergeWindowedEvent:
                 "2024-01-31 12:00:00",
                 12,
                 0,
-                "2024-01-31 12:00:00",
-                -1,
-                id="neg val late time: invalidate label",
+                None,
+                0,
+                id="neg val late time:  NaT+0",
             ),
             pytest.param(
                 3,
@@ -109,9 +109,9 @@ class TestMergeWindowedEvent:
                 "2024-01-31 12:00:00",
                 12,
                 0,
-                "2024-01-31 12:00:00",
-                -1,
-                id="null val late time: impute the invalidate",
+                None,
+                0,
+                id="null val late time:  NaT+0",
             ),
             #
             # predictions at edge of window count
@@ -185,8 +185,8 @@ class TestMergeWindowedEvent:
                 "2024-02-01 01:00:00",
                 10,
                 2,
-                "2024-02-01 01:00:00",
-                -1,
+                None,
+                0,
                 id="offset misses near event; like 4.3",
             ),
             pytest.param(
@@ -263,7 +263,7 @@ class TestMergeWindowedEvent:
                 ["2024-02-01 12:00:00", "2024-02-01 13:00:00"],
                 24,
                 0,
-                "2024-02-01 13:00:00",
+                "2024-02-01 12:00:00",
                 1,
                 id="two later events: impute positive",
             ),
@@ -275,9 +275,9 @@ class TestMergeWindowedEvent:
                 ["2024-01-31 12:00:00", "2024-01-31 11:00:00"],
                 1,
                 0,
-                "2024-01-31 12:00:00",
-                -1,
-                id="two events before prediction: last time",
+                None,
+                0,
+                id="two events before prediction: NaT+0",
             ),
             pytest.param(
                 0,
@@ -286,8 +286,8 @@ class TestMergeWindowedEvent:
                 ["2024-01-31 11:00:00", "2024-01-31 12:00:00"],
                 1,
                 0,
-                "2024-01-31 12:00:00",
-                -1,
+                None,
+                0,
                 id="two events before prediction: last time",
             ),
             pytest.param(
@@ -365,8 +365,8 @@ class TestMergeWindowedEvent:
                 ["2024-01-31 12:00:00", None],
                 12,
                 0,
-                "2024-01-31 12:00:00",
-                -1,
+                None,
+                0,
                 id="late and no time: prioritize known time ('late score')",
             ),
             pytest.param(
@@ -376,8 +376,8 @@ class TestMergeWindowedEvent:
                 [None, "2024-01-31 12:00:00"],
                 12,
                 0,
-                "2024-01-31 12:00:00",
-                -1,
+                None,
+                0,
                 id="late and no time ooo: ",
             ),
             #
@@ -479,29 +479,29 @@ class TestMergeWindowedEvent:
             pytest.param(
                 12,
                 0,
-                [None, "2024-02-02 12:00:00", "2024-02-02 12:00:00", None, "2024-02-04 12:00:00"],
-                [0.0, 2, 2, 3, -1],
+                [None, "2024-02-02 12:00:00", "2024-02-02 12:00:00", None, None],
+                [0.0, 2, 2, 3, 0],
                 id="base lookback",
             ),
             pytest.param(
                 12,
                 2,
-                [None, "2024-02-02 12:00:00", None, None, "2024-02-04 12:00:00"],
-                [0.0, 2, 3, 3, -1],
+                [None, "2024-02-02 12:00:00", None, None, None],
+                [0.0, 2, 3, 3, 0],
                 id="offset out of middle pred window",
             ),
             pytest.param(
                 12,
                 -2,
-                [None, "2024-02-02 12:00:00", "2024-02-02 12:00:00", "2024-02-02 12:00:00", "2024-02-04 12:00:00"],
-                [0.0, 2, 2, 2, -1],
+                [None, "2024-02-02 12:00:00", "2024-02-02 12:00:00", "2024-02-02 12:00:00", None],
+                [0.0, 2, 2, 2, 0],
                 id="offset allow future for third event",
             ),
             pytest.param(
                 1.5,
                 0,
-                [None, None, "2024-02-02 12:00:00", None, "2024-02-04 12:00:00"],
-                [0.0, 2, 2, 3, -1],
+                [None, None, "2024-02-02 12:00:00", None, None],
+                [0.0, 2, 2, 3, 0],
                 id="reduce window out of second event",
             ),
         ],
@@ -583,15 +583,15 @@ class TestMergeWindowedEvent:
                 "2024-02-02 12:00:00",
                 "2024-02-02 12:00:00",
                 None,
-                "2024-02-04 12:00:00",
+                None,
                 None,
                 "2024-02-02 12:00:00",
                 None,
                 None,
-                "2024-02-04 12:00:00",
+                None,
             ]
         )
-        expected_vals = np.hstack(([0.0, 2, 2, 3, -1], np.add([0.0, 2, 3, 3, -6], 5)))  # -6+5=-1
+        expected_vals = np.hstack(([0.0, 2, 2, 3, 0], np.add([0.0, 2, 3, 3, -5], 5)))  # -5+5=0
         predictions = create_prediction_table(ids, csns, predtimes)
         events = create_event_table(
             ids, csns, event_name, event_times=event_times, event_values=range(len(event_times))
@@ -644,15 +644,15 @@ class TestMergeWindowedEvent:
                 "2024-02-02 12:00:00",
                 "2024-02-02 12:00:00",
                 None,
-                "2024-02-04 12:00:00",
+                None,
                 None,
                 "2024-02-02 12:00:00",
                 None,
                 None,
-                "2024-02-04 12:00:00",
+                None,
             ]
         )
-        expected_vals = np.hstack(([0.0, 2, 2, 3, -1], np.add([0.0, 2, 3, 3, -6], 5)))  # -6+5=-1
+        expected_vals = np.hstack(([0.0, 2, 2, 3, 0], np.add([0.0, 2, 3, 3, -5], 5)))  # -5+5=0
         predictions = create_prediction_table(ids, csns, predtimes)
         events = create_event_table(
             ids, csns, event_name, event_times=event_times, event_values=range(len(event_times))

--- a/tests/data/test_pandas_helpers.py
+++ b/tests/data/test_pandas_helpers.py
@@ -51,10 +51,14 @@ class TestMergeFrames:
     @pytest.mark.parametrize("id_,enc", [pytest.param(1, None, id="predictions+outcomes")])
     def test_merge_earliest(self, id_, enc, merge_data):
         data = filter_case(merge_data, id_, enc)
-        # TODO: rename second time
         expect = data.expect.drop(columns=[c for c in data.expect if "Cohort" in c]).rename(columns={"✨Time✨": "Time"})
 
-        actual = undertest._merge_next(data.preds, data.events, ["Id", "Enc"], l_ref="PredictTime")
+        actual = undertest._handle_merge(
+            data.preds.sort_values("PredictTime"),
+            data.events.sort_values("Time"),
+            ["Id", "Enc"],
+            pred_ref="PredictTime",
+        )
 
         # check_like = ignore column order
         pd.testing.assert_frame_equal(actual.reset_index(drop=True), expect, check_like=True, check_dtype=False)

--- a/tests/resources/data/score_selection/expected_event_scores.tsv
+++ b/tests/resources/data/score_selection/expected_event_scores.tsv
@@ -1,4 +1,4 @@
-Id	CSN	ref_event	min	max	first	last
+Id	CtxId	ref_event	min	max	first	last
 1	0	Target	1	21	1	1
 1	0	Reference_5_15_Time	1	21	5	15
 1	0	PredictTime	1	21	1	21

--- a/tests/resources/data/score_selection/input_event_scores.tsv
+++ b/tests/resources/data/score_selection/input_event_scores.tsv
@@ -1,4 +1,4 @@
-Id	CSN		Feature1	ModelScore	PredictTime	Target_Time	Reference_5_15_Time	Target_Value
+Id	CtxId		Feature1	ModelScore	PredictTime	Target_Time	Reference_5_15_Time	Target_Value
 1	0		a	1	2/1/2024 8:00	2/1/2024 12:00	2/1/2024 12:00	1
 1	0		a	2	2/1/2024 8:15	2/1/2024 12:00	2/1/2024 12:00	1
 1	0		a	3	2/1/2024 8:30	2/1/2024 12:00	2/1/2024 12:00	1


### PR DESCRIPTION
# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->
Closes #71 - prevent context_id_x columns.  
Simplifies merge to be a clear 'first' event within window.
  

## Description of changes
- reduce event frame to known columns during merge steps
- Remove coalesce logic for merging on late predictions and a subset of missing times  
- Add separate handling for merging events that never have times
- Add logging back when those missing cases are being hit and what the behavior will be

Needed test updates show fairly nicely that the main change is -1+Time pairs are now 0+NaT, and NaT times (early-out of window) also drop label.  
Minimal impact, since most accesses of the event frames filter to > -1, which is biased toward binary classifiers anyway. Did NOT remove that filtering (yet?).  
This simplification is a good step toward supporting more strategies, which a new collaborator has asked about doing.

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
