### PR TITLE
multi score / multi-target comparison + MultiselectDropdownWidget widget

### DIFF
--- a/changelog/82.feature.rst
+++ b/changelog/82.feature.rst
@@ -1,0 +1,5 @@
+Added ExploreSubgroups as a drop in replacement for sm.cohort_list
+Added ExploreModelScoreComparison to compare two scores againts a shared target
+Added ExploreModelTargetComparison to compare a single score across two targets
+Added MultiselectDropdownWidget as a new widget for selecting cohort_dicts, uses a drop down and dismissalbe tags to keep the UX neater.
+Updated handling around `primary_output` and `outputs`, so that if primary_output is in outputs, it does not get added in again during startup. 

--- a/docs/reference/seismometer.rst
+++ b/docs/reference/seismometer.rst
@@ -10,12 +10,16 @@ Exploration APIs
 .. autosummary::
    :toctree: api/
 
+   ExploreSubgroups
    ExploreModelEvaluation
    ExploreCohortEvaluation
    ExploreCohortHistograms
    ExploreCohortLeadTime
    ExploreCohortOutcomeInterventionTimes
    ExploreFairnessAudit
+   ExploreModelScoreComparison
+   ExploreModelTargetComparison
+   
 
 Public API
 ~~~~~~~~~~~
@@ -52,6 +56,9 @@ Custom Visualization Controls
 
 
    explore.ExplorationWidget
+   explore.ExplorationSubpopulationWidget
    explore.ExplorationModelSubgroupEvaluationWidget
    explore.ExplorationCohortSubclassEvaluationWidget
    explore.ExplorationCohortOutcomeInterventionEvaluationWidget
+   explore.ExplorationScoreComparisonByCohortWidget
+   explore.ExplorationTargetComparisonByCohortWidget

--- a/example-notebooks/binary-classifier/classifier_bin.ipynb
+++ b/example-notebooks/binary-classifier/classifier_bin.ipynb
@@ -261,7 +261,7 @@
    },
    "outputs": [],
    "source": [
-    "sm.cohort_list()"
+    "sm.ExploreSubgroups()"
    ]
   },
   {

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     ipywidgets>=8.0
     jupyterlab>=4.2.5,<5
     matplotlib>=3.6,<4
+    seaborn>=0.13.2,<0.14
     pandas>=1.5.0,<3
     scikit-learn>=1.2.0,<2
     pyarrow>=9.0.0

--- a/src/seismometer/configuration/config.py
+++ b/src/seismometer/configuration/config.py
@@ -102,7 +102,7 @@ class ConfigProvider:
     @property
     def config(self) -> OtherInfo:
         """
-        The configuration definiton.
+        The configuration definition.
 
         Usually from config.yml, this is primarily used during initial loading to know
         where other pieces are located.
@@ -250,6 +250,8 @@ class ConfigProvider:
 
         Configured in usage_data as outputs or primary_output.
         """
+        if self.output in self.usage.outputs:
+            return self.usage.outputs
         return [self.output] + self.usage.outputs
 
     @property

--- a/src/seismometer/configuration/model.py
+++ b/src/seismometer/configuration/model.py
@@ -234,7 +234,7 @@ class DataUsage(BaseModel):
 
     The features and scores list, when defined, limit the loading of data from the predictions file to only those
     inputs and outputs (plus primary_score and cohort attributes).
-    The events similary limits the event types that are merged into the working dataframe and available to analyses.
+    The events similarly limits the event types that are merged into the working dataframe and available to analyses.
     """
 
     entity_id: str = "Id"

--- a/src/seismometer/controls/explore.py
+++ b/src/seismometer/controls/explore.py
@@ -426,7 +426,7 @@ class ModelTargetComparisonOptionsWidget(VBox, ValueWidget):
 
     @property
     def targets(self) -> str:
-        """Target column descriptor"""
+        """Target column descriptors"""
         return self.target_list.value
 
     @property

--- a/src/seismometer/controls/explore.py
+++ b/src/seismometer/controls/explore.py
@@ -4,30 +4,41 @@ from typing import Any, Callable, Literal, Optional
 
 import traitlets
 from IPython.display import display
-from ipywidgets import HTML, Box, Button, Checkbox, Dropdown, FloatSlider, HBox, Layout, Output, ValueWidget, VBox
+from ipywidgets import HTML, Box, Button, Checkbox, Dropdown, FloatSlider, Layout, Output, ValueWidget, VBox
 
-from .selection import DisjointSelectionListsWidget, MultiSelectionListWidget, SelectionListWidget
+from .selection import DisjointSelectionListsWidget, MultiselectDropdownWidget, MultiSelectionListWidget
 from .styles import BOX_GRID_LAYOUT, WIDE_LABEL_STYLE, html_title
 from .thresholds import MonotonicProbabilitySliderListWidget
 
 logger = logging.getLogger("seismometer")
 
+
 # region Model Evaluation Header Controls
+def _combine_scores_checkbox(per_context):
+    """Returns checkbox for if scores should be combined."""
+    return Checkbox(
+        value=per_context,
+        description="Combine scores?",
+        disabled=False,
+        tooltip="Combine scores by taking a representative score from the target window.",
+        style=WIDE_LABEL_STYLE,
+    )
 
 
 class UpdatePlotWidget(Box):
     """Widget for updating plots and showing code behind the plot call."""
 
-    UPDATE_PLOTS = "Update Plots"
+    UPDATE_PLOTS = "Update"
     UPDATING_PLOTS = "Updating ..."
+    SHOW_CODE = "Show code?"
 
     def __init__(self):
         self.code_checkbox = Checkbox(
             value=False,
-            description="show code",
+            description=self.SHOW_CODE,
             disabled=False,
             indent=False,
-            tooltip="Show the code used to generate the plot",
+            tooltip="Show the code used to generate the plot.",
             layout=Layout(margin="var(--jp-widgets-margin) var(--jp-widgets-margin) var(--jp-widgets-margin) 10px;"),
         )
 
@@ -39,6 +50,10 @@ class UpdatePlotWidget(Box):
     @property
     def show_code(self) -> bool:
         return self.code_checkbox.value
+
+    @show_code.setter
+    def show_code(self, show_code: bool) -> bool:
+        self.code_checkbox.value = show_code
 
     @property
     def disabled(self) -> bool:
@@ -69,7 +84,7 @@ class UpdatePlotWidget(Box):
 
 
 class ModelOptionsWidget(VBox, ValueWidget):
-    value = traitlets.Dict(help="The selected values for the model options")
+    value = traitlets.Dict(help="The selected values for the model options.")
 
     def __init__(
         self,
@@ -78,18 +93,19 @@ class ModelOptionsWidget(VBox, ValueWidget):
         thresholds: Optional[dict[str, float]] = None,
         per_context: Optional[bool] = None,
     ):
-        """Widget for model based options
+        """
+        Widget for model options.
 
         Parameters
         ----------
         target_names : tuple[Any]
-            list of target column names
+            List of target column names.
         score_names : tuple[Any]
-            list of model score names
+            List of model score names.
         thresholds : dict[str, float]
-            list of thresholds for the model scores, will be sorted into decreasing order
+            List of thresholds for the model scores, will be sorted into decreasing order.
         per_context : bool, optional
-            if scores should be grouped by context, by default None, in which case this checkbox is not shown.
+            If scores should be grouped by context, by default None, in which case this checkbox is not shown.
         """
         self.title = html_title("Model Options")
         self.target_list = Dropdown(
@@ -119,13 +135,7 @@ class ModelOptionsWidget(VBox, ValueWidget):
             self.threshold_list = None
 
         if per_context is not None:
-            self.per_context_checkbox = Checkbox(
-                value=per_context,
-                description="combine scores",
-                disabled=False,
-                tooltip="Combine scores by taking the maximum score in the target window",
-                style=WIDE_LABEL_STYLE,
-            )
+            self.per_context_checkbox = _combine_scores_checkbox(per_context)
             children.append(self.per_context_checkbox)
             self.per_context_checkbox.observe(self._on_value_change, "value")
         else:
@@ -135,6 +145,7 @@ class ModelOptionsWidget(VBox, ValueWidget):
             children=children,
             layout=Layout(align_items="flex-start", flex="0 0 auto"),
         )
+        self._on_value_change()
         self._disabled = False
 
     @property
@@ -161,40 +172,128 @@ class ModelOptionsWidget(VBox, ValueWidget):
 
     @property
     def target(self) -> str:
-        """target column descriptor"""
+        """Target column descriptor"""
         return self.target_list.value
 
     @property
     def score(self) -> str:
-        """score column descriptor"""
+        """Score column descriptor"""
         return self.score_list.value
 
     @property
     def thresholds(self) -> tuple[float]:
-        """thresholds for the score"""
+        """Thresholds for the score"""
         if self.threshold_list:
             return self.threshold_list.value
 
     @property
     def group_scores(self) -> bool:
-        """if the scores should be grouped"""
+        """If scores should be grouped by context."""
         if self.per_context_checkbox:
             return self.per_context_checkbox.value
 
 
-class ModelOptionsAndCohortsWidget(Box, ValueWidget):
-    value = traitlets.Dict(help="The selected values for the cohorts and model options")
+class ModelScoreComparisonOptionsWidget(VBox, ValueWidget):
+    value = traitlets.Dict(help="The selected values for the model options and scores to compare.")
+
+    def __init__(
+        self,
+        target_names: tuple[Any],
+        score_names: tuple[Any],
+        per_context: Optional[bool] = None,
+    ):
+        """
+        Widget for model based options, including scores to compare.
+
+        Parameters
+        ----------
+        target_names : tuple[Any]
+            List of target column names.
+        score_names : tuple[Any]
+            List of model score names.
+        per_context : bool, optional
+            If scores should be grouped by context, by default None, in which case this checkbox is not shown.
+        """
+        self.title = html_title("Model Options")
+        self.target_list = Dropdown(
+            options=target_names,
+            value=target_names[0],
+            description="Target Column",
+            style=WIDE_LABEL_STYLE,
+        )
+        self.score_list = MultiselectDropdownWidget(
+            options=score_names, value=score_names[0:2], title="Compare Scores"
+        )
+
+        self.target_list.observe(self._on_value_change, "value")
+        self.score_list.observe(self._on_value_change, "value")
+        children = [
+            self.title,
+            VBox(children=[self.target_list, self.score_list], layout=Layout(align_items="flex-end")),
+        ]
+
+        if per_context is not None:
+            self.per_context_checkbox = _combine_scores_checkbox(per_context)
+            children.append(self.per_context_checkbox)
+            self.per_context_checkbox.observe(self._on_value_change, "value")
+        else:
+            self.per_context_checkbox = None
+
+        super().__init__(
+            children=children,
+            layout=Layout(align_items="flex-start", flex="0 0 auto"),
+        )
+        self._on_value_change()
+        self._disabled = False
+
+    @property
+    def disabled(self) -> bool:
+        return self._disabled
+
+    @disabled.setter
+    def disabled(self, disabled: bool):
+        self._disabled = disabled
+        self.target_list.disabled = disabled
+        self.score_list.disabled = disabled
+        if self.per_context_checkbox:
+            self.per_context_checkbox.disabled = disabled
+
+    def _on_value_change(self, change=None):
+        self.value = {
+            "target": self.target,
+            "scores": self.scores,
+            "group_scores": self.group_scores,
+        }
+
+    @property
+    def target(self) -> str:
+        """Target column descriptor"""
+        return self.target_list.value
+
+    @property
+    def scores(self) -> tuple[str]:
+        """Score column descriptor"""
+        return self.score_list.value
+
+    @property
+    def group_scores(self) -> bool:
+        """If scores should be grouped by context."""
+        if self.per_context_checkbox:
+            return self.per_context_checkbox.value
+
+
+class ModelScoreComparisonAndCohortsWidget(Box, ValueWidget):
+    value = traitlets.Dict(help="The selected values for the cohorts and model options.")
 
     def __init__(
         self,
         cohort_groups: dict[str, tuple[Any]],
         target_names: tuple[Any],
         score_names: tuple[Any],
-        thresholds: dict[str, float],
         per_context: bool = False,
     ):
         """
-        Widget for model based options and cohort selection
+        Widget for model based options and cohort selection, including scores to compare.
 
         Parameters
         ----------
@@ -204,18 +303,17 @@ class ModelOptionsAndCohortsWidget(Box, ValueWidget):
             model target columns
         score_names : tuple[Any]
             model score columns
-        thresholds : dict[str, float]
-            model thresholds
         per_context : bool, optional
             if scores should be grouped by context, by default False
         """
         self.cohort_list = MultiSelectionListWidget(options=cohort_groups, title="Cohort Filter")
-        self.model_options = ModelOptionsWidget(target_names, score_names, thresholds, per_context)
+        self.model_options = ModelScoreComparisonOptionsWidget(target_names, score_names, per_context)
         self.cohort_list.observe(self._on_value_change, "value")
         self.model_options.observe(self._on_value_change, "value")
 
         super().__init__(children=[self.model_options, self.cohort_list], layout=BOX_GRID_LAYOUT)
 
+        self._on_value_change()
         self._disabled = False
 
     @property
@@ -236,12 +334,245 @@ class ModelOptionsAndCohortsWidget(Box, ValueWidget):
 
     @property
     def cohorts(self) -> dict[str, tuple[str]]:
-        """selected cohorts"""
+        """Selected cohorts"""
         return self.cohort_list.value
 
     @property
     def target(self) -> str:
-        """target column descriptor"""
+        """Target column descriptor"""
+        return self.model_options.target
+
+    @property
+    def scores(self) -> tuple[str]:
+        """Score column descriptors"""
+        return self.model_options.scores
+
+    @property
+    def group_scores(self) -> bool:
+        """If scores should be grouped by context."""
+        return self.model_options.group_scores
+
+
+class ModelTargetComparisonOptionsWidget(VBox, ValueWidget):
+    value = traitlets.Dict(help="The selected values for the model options and targets to evaluate.")
+
+    def __init__(
+        self,
+        target_names: tuple[Any],
+        score_names: tuple[Any],
+        per_context: Optional[bool] = None,
+    ):
+        """
+        Widget for model based options, including multiple targets.
+
+        Parameters
+        ----------
+        target_names : tuple[Any]
+            List of target names
+        score_names : tuple[Any]
+            List of model score names
+        per_context : bool, optional
+            If scores should be grouped by context, by default None, in which case this checkbox is not shown.
+        """
+        self.title = html_title("Model Options")
+        self.target_list = MultiselectDropdownWidget(
+            options=target_names, value=target_names[0:2], title="Compare Targets"
+        )
+        self.score_list = Dropdown(
+            options=score_names,
+            value=score_names[0],
+            description="Score Column",
+            style=WIDE_LABEL_STYLE,
+        )
+        self.target_list.observe(self._on_value_change, "value")
+        self.score_list.observe(self._on_value_change, "value")
+        children = [
+            self.title,
+            VBox(children=[self.target_list, self.score_list], layout=Layout(align_items="flex-end")),
+        ]
+
+        if per_context is not None:
+            self.per_context_checkbox = _combine_scores_checkbox(per_context)
+            children.append(self.per_context_checkbox)
+            self.per_context_checkbox.observe(self._on_value_change, "value")
+        else:
+            self.per_context_checkbox = None
+
+        super().__init__(
+            children=children,
+            layout=Layout(align_items="flex-start", flex="0 0 auto"),
+        )
+        self._on_value_change()
+        self._disabled = False
+
+    @property
+    def disabled(self) -> bool:
+        return self._disabled
+
+    @disabled.setter
+    def disabled(self, disabled: bool):
+        self._disabled = disabled
+        self.target_list.disabled = disabled
+        self.score_list.disabled = disabled
+        if self.per_context_checkbox:
+            self.per_context_checkbox.disabled = disabled
+
+    def _on_value_change(self, change=None):
+        self.value = {
+            "targets": self.targets,
+            "score": self.score,
+            "group_scores": self.group_scores,
+        }
+
+    @property
+    def targets(self) -> str:
+        """Target column descriptor"""
+        return self.target_list.value
+
+    @property
+    def score(self) -> tuple[str]:
+        """Score column descriptor"""
+        return self.score_list.value
+
+    @property
+    def group_scores(self) -> bool:
+        """If scores should be grouped by context."""
+        if self.per_context_checkbox:
+            return self.per_context_checkbox.value
+
+
+class ModelTargetComparisonAndCohortsWidget(Box, ValueWidget):
+    value = traitlets.Dict(help="The selected values for the cohorts and model options and targets.")
+
+    def __init__(
+        self,
+        cohort_groups: dict[str, tuple[Any]],
+        target_names: tuple[Any],
+        score_names: tuple[Any],
+        per_context: bool = False,
+    ):
+        """
+        Widget for model based options and cohort selection, including multiple targets.
+
+        Parameters
+        ----------
+        cohort_groups : dict[str, tuple[Any]]
+            Cohort columns and groupings
+        target_names : tuple[Any]
+            List of model target descriptors
+        score_names : tuple[Any]
+            List of model score names
+        per_context : bool, optional
+            If scores should be grouped by context, by default False.
+        """
+        self.cohort_list = MultiSelectionListWidget(options=cohort_groups, title="Cohort Filter")
+        self.model_options = ModelTargetComparisonOptionsWidget(target_names, score_names, per_context)
+        self.cohort_list.observe(self._on_value_change, "value")
+        self.model_options.observe(self._on_value_change, "value")
+
+        super().__init__(children=[self.model_options, self.cohort_list], layout=BOX_GRID_LAYOUT)
+
+        self._on_value_change()
+        self._disabled = False
+
+    @property
+    def disabled(self) -> bool:
+        return self._disabled
+
+    @disabled.setter
+    def disabled(self, disabled: bool):
+        self._disabled = disabled
+        self.cohort_list.disabled = disabled
+        self.model_options.disabled = disabled
+
+    def _on_value_change(self, change=None):
+        self.value = {
+            "cohorts": self.cohort_list.value,
+            "model_options": self.model_options.value,
+        }
+
+    @property
+    def cohorts(self) -> dict[str, tuple[str]]:
+        """Selected cohorts"""
+        return self.cohort_list.value
+
+    @property
+    def targets(self) -> str:
+        """Target column descriptors"""
+        return self.model_options.targets
+
+    @property
+    def score(self) -> tuple[str]:
+        """Score column descriptor"""
+        return self.model_options.score
+
+    @property
+    def group_scores(self) -> bool:
+        """If scores should be grouped by context."""
+        return self.model_options.group_scores
+
+
+class ModelOptionsAndCohortsWidget(Box, ValueWidget):
+    value = traitlets.Dict(help="The selected values for the cohorts and model options.")
+
+    def __init__(
+        self,
+        cohort_groups: dict[str, tuple[Any]],
+        target_names: tuple[Any],
+        score_names: tuple[Any],
+        thresholds: dict[str, float],
+        per_context: bool = False,
+    ):
+        """
+        Widget for model based options and cohort selection.
+
+        Parameters
+        ----------
+        cohort_groups : dict[str, tuple[Any]]
+            cohort columns and groupings
+        target_names : tuple[Any]
+            model target columns
+        score_names : tuple[Any]
+            model score columns
+        thresholds : dict[str, float]
+            model thresholds
+        per_context : bool, optional
+            If scores should be grouped by context, by default False.
+        """
+        self.cohort_list = MultiSelectionListWidget(options=cohort_groups, title="Cohort Filter")
+        self.model_options = ModelOptionsWidget(target_names, score_names, thresholds, per_context)
+        self.cohort_list.observe(self._on_value_change, "value")
+        self.model_options.observe(self._on_value_change, "value")
+
+        super().__init__(children=[self.model_options, self.cohort_list], layout=BOX_GRID_LAYOUT)
+
+        self._on_value_change()
+        self._disabled = False
+
+    @property
+    def disabled(self) -> bool:
+        return self._disabled
+
+    @disabled.setter
+    def disabled(self, disabled: bool):
+        self._disabled = disabled
+        self.cohort_list.disabled = disabled
+        self.model_options.disabled = disabled
+
+    def _on_value_change(self, change=None):
+        self.value = {
+            "cohorts": self.cohort_list.value,
+            "model_options": self.model_options.value,
+        }
+
+    @property
+    def cohorts(self) -> dict[str, tuple[str]]:
+        """Selected cohorts"""
+        return self.cohort_list.value
+
+    @property
+    def target(self) -> str:
+        """Target column descriptor"""
         return self.model_options.target
 
     @property
@@ -256,12 +587,12 @@ class ModelOptionsAndCohortsWidget(Box, ValueWidget):
 
     @property
     def group_scores(self) -> bool:
-        """If scores should be grouped by context"""
+        """If scores should be grouped by context."""
         return self.model_options.group_scores
 
 
 class ModelOptionsAndCohortGroupWidget(Box, ValueWidget):
-    value = traitlets.Dict(help="The selected values for the cohorts and model options")
+    value = traitlets.Dict(help="The selected values for the cohorts and model options.")
 
     def __init__(
         self,
@@ -273,7 +604,7 @@ class ModelOptionsAndCohortGroupWidget(Box, ValueWidget):
     ):
         """
         Selection widget for model options and cohort groups, when displaying results for
-        individual values within a cohort attribute
+        individual values within a cohort attribute.
 
         Parameters
         ----------
@@ -286,7 +617,7 @@ class ModelOptionsAndCohortGroupWidget(Box, ValueWidget):
         thresholds : dict[str, float]
             thresholds for the model scores
         per_context : bool, optional
-            if scores should be grouped by context, by default False
+            If scores should be grouped by context, by default False.
         """
         self.cohort_list = DisjointSelectionListsWidget(options=cohort_groups, title="Cohort Filter", select_all=True)
         self.model_options = ModelOptionsWidget(target_names, score_names, thresholds, per_context)
@@ -294,6 +625,8 @@ class ModelOptionsAndCohortGroupWidget(Box, ValueWidget):
         self.model_options.observe(self._on_value_change, "value")
 
         super().__init__(children=[self.model_options, self.cohort_list], layout=BOX_GRID_LAYOUT)
+
+        self._on_value_change()
         self._disabled = False
 
     @property
@@ -314,32 +647,32 @@ class ModelOptionsAndCohortGroupWidget(Box, ValueWidget):
 
     @property
     def cohort(self) -> str:
-        """cohort column descriptor"""
+        """Cohort column descriptor"""
         return self.cohort_list.value[0]
 
     @property
     def cohort_groups(self) -> tuple[Any]:
-        """cohort groups"""
+        """Cohort groups"""
         return self.cohort_list.value[1]
 
     @property
     def target(self) -> str:
-        """target column descriptor"""
+        """Target column descriptor"""
         return self.model_options.target
 
     @property
     def score(self) -> str:
-        """score column descriptor"""
+        """Score column descriptor"""
         return self.model_options.score
 
     @property
     def thresholds(self) -> tuple[float]:
-        """score thresholds"""
+        """Score thresholds"""
         return self.model_options.thresholds
 
     @property
     def group_scores(self) -> bool:
-        """if scores should be grouped by context"""
+        """If scores should be grouped by context."""
         return self.model_options.group_scores
 
 
@@ -353,16 +686,16 @@ class ModelInterventionOptionsWidget(VBox, ValueWidget):
         reference_time_names: tuple[Any] = None,
     ):
         """
-        Widget for selecting an intervention and outcome for a model implementation
+        Widget for selecting an intervention and outcome for a model implementation.
 
         Parameters
         ----------
         outcome_names : tuple[Any], optional
-            names of outcome columns, by default None
+            Names of outcome columns, by default None.
         intervention_names : tuple[Any], optional
-            names of intervention columns, by default None
+            Names of intervention columns, by default None.
         reference_time_names : tuple[Any], optional
-            name for the reference time to align patients, by default None
+            Name for the reference time to align patients, by default None.
         """
         self.title = html_title("Model Options")
         self.outcome_list = Dropdown(options=outcome_names, value=outcome_names[0], description="Outcome")
@@ -383,6 +716,8 @@ class ModelInterventionOptionsWidget(VBox, ValueWidget):
         self.outcome_list.observe(self._on_value_change, "value")
         self.intervention_list.observe(self._on_value_change, "value")
         self.reference_time_list.observe(self._on_value_change, "value")
+
+        self._on_value_change()
         self._disabled = False
 
     @property
@@ -405,17 +740,17 @@ class ModelInterventionOptionsWidget(VBox, ValueWidget):
 
     @property
     def outcome(self) -> str:
-        """outcome column descriptor"""
+        """Outcome column descriptor"""
         return self.outcome_list.value
 
     @property
     def intervention(self) -> str:
-        """intervention column descriptor"""
+        """Intervention column descriptor"""
         return self.intervention_list.value
 
     @property
     def reference_time(self) -> str:
-        """reference time column descriptor"""
+        """Reference time column descriptor"""
         return self.reference_time_list.value
 
 
@@ -435,13 +770,13 @@ class ModelInterventionAndCohortGroupWidget(Box, ValueWidget):
         Parameters
         ----------
         cohort_groups : dict[str, tuple[Any]]
-            cohort names and category values
+            Cohort names and category values.
         outcome_names : tuple[Any], optional
-            outcome descriptors, by default None
+            Outcome descriptors, by default None.
         intervention_names : tuple[Any], optional
-            intervention descriptors, by default None
+            Intervention descriptors, by default None.
         reference_time_names : tuple[Any], optional
-            reference time descriptors, by default None
+            Reference time descriptors, by default None.
         """
         self.cohort_list = DisjointSelectionListsWidget(options=cohort_groups, title="Cohort Filter", select_all=True)
         self.model_options = ModelInterventionOptionsWidget(outcome_names, intervention_names, reference_time_names)
@@ -449,6 +784,8 @@ class ModelInterventionAndCohortGroupWidget(Box, ValueWidget):
         self.model_options.observe(self._on_value_change, "value")
 
         super().__init__(children=[self.model_options, self.cohort_list], layout=BOX_GRID_LAYOUT)
+
+        self._on_value_change()
         self._disabled = False
 
     @property
@@ -469,32 +806,32 @@ class ModelInterventionAndCohortGroupWidget(Box, ValueWidget):
 
     @property
     def cohort(self) -> str:
-        """cohort column descriptor"""
+        """Cohort column descriptor"""
         return self.cohort_list.value[0]
 
     @property
     def cohort_groups(self) -> tuple[Any]:
-        """cohort category values"""
+        """Cohort category values"""
         return self.cohort_list.value[1]
 
     @property
     def outcome(self) -> str:
-        """outcome column descriptor"""
+        """Outcome column descriptor"""
         return self.model_options.outcome
 
     @property
     def intervention(self) -> str:
-        """intervention column descriptor"""
+        """Intervention column descriptor"""
         return self.model_options.intervention
 
     @property
     def reference_time(self) -> str:
-        """reference time column descriptor"""
+        """Reference time column descriptor"""
         return self.model_options.reference_time
 
 
 class ModelFairnessAuditOptions(Box, ValueWidget):
-    value = traitlets.Dict(help="The selected values for the audit and model options")
+    value = traitlets.Dict(help="The selected values for the audit and model options.")
 
     def __init__(
         self,
@@ -511,17 +848,17 @@ class ModelFairnessAuditOptions(Box, ValueWidget):
         Parameters
         ----------
         target_names : tuple[Any]
-            model target columns
+            Model target columns.
         score_names : tuple[Any]
-            model score columns
+            Model score columns.
         score_threshold : float
-            main threshold for the model score
+            Main threshold for the model score.
         per_context : bool, optional
-            if scores should be grouped by context, by default True
+            If scores should be grouped by context, by default True.
         fairness_metrics : tuple[str], optional
-            list of fairness metrics to display, if None (default) will use ["tpr", "fpr", "pprev"]
+            List of fairness metrics to display, if None (default) will use ["tpr", "fpr", "pprev"].
         fairness_threshold : float, optional
-            threshold for fairness metrics, by default 1.25
+            Threshold for fairness metrics, by default 1.25.
         """
         all_metrics = ["pprev", "tpr", "fpr", "fnr", "ppr", "precision"]
         fairness_metrics = fairness_metrics or ["pprev", "tpr", "fpr"]
@@ -535,9 +872,10 @@ class ModelFairnessAuditOptions(Box, ValueWidget):
             style=WIDE_LABEL_STYLE,
         )
         thresholds = {"Score Threshold": score_threshold}
-        self.fairness_list = SelectionListWidget(options=all_metrics, value=fairness_metrics, title="Metrics")
+        self.fairness_list = MultiselectDropdownWidget(options=all_metrics, value=fairness_metrics, title="Metrics")
         fairness_section = VBox(
-            children=[html_title("Audit Options"), HBox(children=[self.fairness_list, self.fairness_slider])]
+            children=[html_title("Audit Options"), self.fairness_slider, self.fairness_list],
+            layout=Layout(align_items="flex-end"),
         )
         self.model_options = ModelOptionsWidget(target_names, score_names, thresholds, per_context)
 
@@ -546,6 +884,8 @@ class ModelFairnessAuditOptions(Box, ValueWidget):
         self.fairness_list.observe(self._on_value_change, "value")
         self.fairness_slider.observe(self._on_value_change, "value")
         self.model_options.observe(self._on_value_change, "value")
+
+        self._on_value_change()
         self._disabled = False
 
     @property
@@ -568,17 +908,17 @@ class ModelFairnessAuditOptions(Box, ValueWidget):
 
     @property
     def metrics(self) -> tuple[str]:
-        """selected cohorts"""
+        """Selected cohorts"""
         return self.fairness_list.value
 
     @property
     def fairness_threshold(self) -> tuple[str]:
-        """selected cohorts"""
+        """Threshold under which differences are considered to be fair."""
         return self.fairness_slider.value
 
     @property
     def target(self) -> str:
-        """target column descriptor"""
+        """Target column descriptor"""
         return self.model_options.target
 
     @property
@@ -593,7 +933,7 @@ class ModelFairnessAuditOptions(Box, ValueWidget):
 
     @property
     def group_scores(self) -> bool:
-        """If scores should be grouped by context"""
+        """If scores should be grouped by context."""
         return self.model_options.group_scores
 
 
@@ -606,17 +946,22 @@ class ExplorationWidget(VBox):
     Parent class for model exploration widgets.
     """
 
-    def __init__(self, title: str, option_widget: ValueWidget, plot_function: Callable[..., Any]):
-        """Parent class for a plot exploration widget.
+    NO_CODE_STRING = "No plot generated."
+
+    def __init__(
+        self, title: str, option_widget: ValueWidget, plot_function: Callable[..., Any], initial_plot: bool = True
+    ):
+        """
+        Parent class for a plot exploration widget.
 
         Parameters
         ----------
         title : str
-            Widget title
+            Widget title.
         option_widget : ValueWidget
-            widget that contains the options the plot_function
+            Widget that contains the options the plot_function.
         plot_function : Callable[..., Any]
-            a function that generates content for display within the control.
+            A function that generates content for display within the control.
         """
         layout = Layout(
             width="100%",
@@ -635,7 +980,10 @@ class ExplorationWidget(VBox):
         )
 
         # show initial plot
-        self.update_plot(initial=True)
+        if initial_plot:
+            self.update_plot(initial=True)
+        else:
+            self.current_plot_code = self.NO_CODE_STRING
 
         # attache event handlers
         self.option_widget.observe(self._on_option_change, "value")
@@ -652,30 +1000,40 @@ class ExplorationWidget(VBox):
     @property
     def show_code(self) -> bool:
         """
-        If the widget should show the plot's code
+        If the widget should show the plot's code.
         """
         return self.update_plot_widget.show_code
+
+    @show_code.setter
+    def show_code(self, show_code: bool):
+        self.update_plot_widget.show_code = show_code
 
     def update_plot(self, initial: bool = False):
         plot_args, plot_kwargs = self.generate_plot_args()
         self.current_plot_code = self.generate_plot_code(plot_args, plot_kwargs)
-        plot = self.plot_function(*plot_args, **plot_kwargs)
+        try:
+            plot = self.plot_function(*plot_args, **plot_kwargs)
+        except Exception as e:
+            import traceback
+
+            plot = HTML(f"<div><h3>Exception: <pre>{e}</pre> </h3><pre>{traceback.format_exc()}</pre></div>")
         if not initial:
             self.center.clear_output()
             with self.center:
                 display(plot)
         else:
             self.center.append_display_data(plot)
+        self.update_plot_widget.disabled = True
 
     def _on_plot_button_click(self, button=None):
-        """handle for the update plot button"""
+        """Handle for the update plot button."""
         self.option_widget.disabled = True
         self.update_plot()
         self._on_toggle_code(self.show_code)
         self.option_widget.disabled = False
 
     def generate_plot_code(self, plot_args: tuple = None, plot_kwargs: dict = None) -> str:
-        """String representation of the plot's code"""
+        """String representation of the plot's code."""
         plot_module = self.plot_function.__module__
         plot_method = self.plot_function.__name__
 
@@ -698,7 +1056,7 @@ class ExplorationWidget(VBox):
         return f"{method_string}({args_string})"
 
     def _on_toggle_code(self, show_code: bool):
-        """handle for the toggle code checkbox"""
+        """Handle for the toggle code checkbox."""
         self.code_output.clear_output()
         if not show_code:
             return
@@ -711,12 +1069,57 @@ class ExplorationWidget(VBox):
             display(highlighted_code)
 
     def _on_option_change(self, change=None):
-        """enable the plot to be updated"""
+        """Enable the plot to be updated."""
         self.update_plot_widget.disabled = self.disabled
 
     def generate_plot_args(self) -> tuple[tuple, dict]:
-        """override this method with code to show a plot"""
+        """Override this method with code to show a plot."""
         raise NotImplementedError("Subclasses must implement this method")
+
+
+class ExplorationSubpopulationWidget(ExplorationWidget):
+    """
+    A widget for exploring subpopulations based on cohort selection.
+    """
+
+    def __init__(
+        self,
+        title: str,
+        plot_function: Callable[..., Any],
+    ):
+        """
+        Exploration widget for a subpopulation defined by a cohort selection.
+
+        Parameters
+        ----------
+        title : str
+            Title of the control..
+        plot_function : Callable[..., Any]
+            Expected to have the following signature:
+
+            .. code:: python
+
+                def plot_function(cohort_dict: dict[str,tuple[Any]]) -> Any
+        """
+        from seismometer.seismogram import Seismogram
+
+        sg = Seismogram()
+        cohort_groups = sg.available_cohort_groups
+        option_widget = MultiSelectionListWidget(options=cohort_groups, title="Cohort Filter")
+        option_widget.layout = BOX_GRID_LAYOUT
+        super().__init__(
+            title=title,
+            option_widget=option_widget,
+            plot_function=plot_function,
+        )
+
+    def generate_plot_args(self) -> tuple[tuple, dict]:
+        """Generates the plot arguments for the model evaluation plot."""
+        args = (self.option_widget.value,)
+        kwargs = {
+            # empty dictionary
+        }
+        return args, kwargs
 
 
 class ExplorationModelSubgroupEvaluationWidget(ExplorationWidget):
@@ -736,14 +1139,14 @@ class ExplorationModelSubgroupEvaluationWidget(ExplorationWidget):
         Parameters
         ----------
         title : str
-            title of the control
+            Title of the control.
         plot_function : Callable[..., Any]
             Expected to have the following signature:
 
             .. code:: python
 
                 def plot_function(
-                    cohorts: dict[str,tuple[Any]]
+                    cohort_dict: dict[str,tuple[Any]],
                     target: str,
                     score: str,
                     thresholds: tuple[float],
@@ -762,7 +1165,7 @@ class ExplorationModelSubgroupEvaluationWidget(ExplorationWidget):
         )
 
     def generate_plot_args(self) -> tuple[tuple, dict]:
-        """Generates the plot arguments for the model evaluation plot"""
+        """Generates the plot arguments for the model evaluation plot."""
         args = (
             self.option_widget.cohorts,
             self.option_widget.target,
@@ -795,7 +1198,7 @@ class ExplorationCohortSubclassEvaluationWidget(ExplorationWidget):
         Parameters
         ----------
         title : str
-            title of the control
+            Title of the control.
         plot_function : Callable[..., Any]
             Expected to have the following signature:
 
@@ -839,7 +1242,7 @@ class ExplorationCohortSubclassEvaluationWidget(ExplorationWidget):
         return not self.option_widget.cohort_groups
 
     def generate_plot_args(self) -> tuple[tuple, dict]:
-        """Generates the plot arguments for the model evaluation plot"""
+        """Generates the plot arguments for the model evaluation plot."""
 
         args = [
             self.option_widget.cohort,
@@ -875,7 +1278,7 @@ class ExplorationCohortOutcomeInterventionEvaluationWidget(ExplorationWidget):
         Parameters
         ----------
         title : str
-            title of the control
+            Title of the control.
         plot_function : Callable[..., Any]
             Expected to have the following signature:
 
@@ -907,7 +1310,7 @@ class ExplorationCohortOutcomeInterventionEvaluationWidget(ExplorationWidget):
         )
 
     def generate_plot_args(self) -> tuple[tuple, dict]:
-        """Generates the plot arguments for the model evaluation plot"""
+        """Generates the plot arguments for the model evaluation plot."""
         args = [
             self.option_widget.cohort,
             self.option_widget.cohort_groups,
@@ -916,6 +1319,108 @@ class ExplorationCohortOutcomeInterventionEvaluationWidget(ExplorationWidget):
             self.option_widget.reference_time,
         ]
         kwargs = {}
+        return args, kwargs
+
+
+class ExplorationScoreComparisonByCohortWidget(ExplorationWidget):
+    """
+    A widget to explore different model scores based on a cohort selection.
+    """
+
+    def __init__(self, title: str, plot_function: Callable[..., Any]):
+        """
+        Exploration widget for model score comparison, showing a plot for a given target
+        and cohort selection, across different scores.
+
+        Parameters
+        ----------
+        title : str
+            Title of the control.
+        plot_function : Callable[..., Any]
+            Expected to have the following signature:
+
+            .. code:: python
+
+                def plot_function(
+                    cohort_dict: dict[str,tuple[Any]],
+                    target: str,
+                    scores: tuple[str],
+                    *, per_context: bool) -> Any
+        """
+        from seismometer.seismogram import Seismogram
+
+        sg = Seismogram()
+        super().__init__(
+            title,
+            option_widget=ModelScoreComparisonAndCohortsWidget(
+                sg.available_cohort_groups, sg.target_cols, sg.output_list, per_context=False
+            ),
+            plot_function=plot_function,
+        )
+
+    @property
+    def disabled(self):
+        return len(self.option_widget.scores) < 2
+
+    def generate_plot_args(self) -> tuple[tuple, dict]:
+        """Generates the plot arguments for the model evaluation plot."""
+        args = [
+            self.option_widget.cohorts,
+            self.option_widget.target,
+            self.option_widget.scores,
+        ]
+        kwargs = {"per_context": self.option_widget.group_scores}
+        return args, kwargs
+
+
+class ExplorationTargetComparisonByCohortWidget(ExplorationWidget):
+    """
+    A widget to explore different model targets based on a cohort selection.
+    """
+
+    def __init__(self, title: str, plot_function: Callable[..., Any]):
+        """
+        Exploration widget for model target comparison, showing a plot for a given scores
+        and cohort selection, across different targets.
+
+        Parameters
+        ----------
+        title : str
+            Title of the control.
+        plot_function : Callable[..., Any]
+            Expected to have the following signature:
+
+            .. code:: python
+
+                def plot_function(
+                    cohort_dict: dict[str,tuple[Any]],
+                    targets: tuple[str],
+                    score: str,
+                    *, per_context: bool) -> Any
+        """
+        from seismometer.seismogram import Seismogram
+
+        sg = Seismogram()
+        super().__init__(
+            title,
+            option_widget=ModelTargetComparisonAndCohortsWidget(
+                sg.available_cohort_groups, sg.target_cols, sg.output_list, per_context=False
+            ),
+            plot_function=plot_function,
+        )
+
+    @property
+    def disabled(self):
+        return len(self.option_widget.targets) < 2
+
+    def generate_plot_args(self) -> tuple[tuple, dict]:
+        """Generates the plot arguments for the model evaluation plot."""
+        args = [
+            self.option_widget.cohorts,
+            self.option_widget.targets,
+            self.option_widget.score,
+        ]
+        kwargs = {"per_context": self.option_widget.group_scores}
         return args, kwargs
 
 

--- a/src/seismometer/controls/styles.py
+++ b/src/seismometer/controls/styles.py
@@ -5,10 +5,10 @@ WIDE_LABEL_STYLE = {"description_width": "120px"}
 BOX_GRID_LAYOUT = Layout(
     align_items="flex-start", grid_gap="20px", width="100%", min_width="300px", max_width="1200px"
 )
-WIDE_BUTTON_LAYOUT = Layout(align_items="flex-start", width="max-content", min_width="200px")
+WIDE_BUTTON_LAYOUT = Layout(align_items="flex-start", width="max-content", min_width="150px", max_width="300px")
 DROPDOWN_LAYOUT = Layout(width="calc(max(max-content, var(--jp-widgets-inline-width-short)))")
 
 
-def html_title(title: str) -> HTML:
+def html_title(title: str, block: bool = True) -> HTML:
     """html title style"""
-    return HTML(f'<h4 style="text-align: left;  margin: 0px;">{title}</h4>')
+    return HTML(f'<h4 style="text-align: left;  margin: 0px;">{title}</h4>', layout=Layout(align_self="flex-start"))

--- a/src/seismometer/controls/thresholds.py
+++ b/src/seismometer/controls/thresholds.py
@@ -44,6 +44,7 @@ class ProbabilitySliderListWidget(ValueWidget, VBox):
                 max=1.0,
                 step=0.01,
                 description=name,
+                tooltip=name,
                 disabled=False,
                 continuous_update=False,
                 orientation="horizontal",

--- a/src/seismometer/data/cohorts.py
+++ b/src/seismometer/data/cohorts.py
@@ -141,6 +141,9 @@ def get_cohort_performance_data(
             pd.DataFrame({"cohort": label, "cohort-count": 0, "cohort-targetcount": 0}, index=[0])
         )
 
+    if not cohort_perf_stats:
+        return pd.DataFrame()
+
     frame = pd.concat(cohort_perf_stats, ignore_index=True)
     frame["cohort"] = frame["cohort"].astype(pd.CategoricalDtype(data["cohort"].cat.categories))
 
@@ -263,7 +266,7 @@ def label_cohorts_categorical(series: SeriesOrArray, cat_values: Optional[list] 
     series : SeriesOrArray
         pandas series of data to bin.
     cat_values : Optional[list], optional
-        List of categories to reduce to (default: None-> all observeded categories).
+        List of categories to reduce to (default: None-> all observed categories).
 
     Returns
     -------

--- a/src/seismometer/seismogram.py
+++ b/src/seismometer/seismogram.py
@@ -28,7 +28,7 @@ class Seismogram(object, metaclass=Singleton):
             b. Source Data
         2. Hold the current dynamic configuration that is shared state.
             a. Cohort Selection
-        3. Providing data accces for other objects without compromising the source data.
+        3. Providing data access for other objects without compromising the source data.
             a. Merge Event data with Prediction data for Label generation
             b. Cohort based data selection
             c. Model configuration help texts
@@ -324,7 +324,7 @@ class Seismogram(object, metaclass=Singleton):
     # region initialization and preprocessing (this region knows about config)
     def copy_config_metadata(self):
         """
-        Loads the base configuration and alerting congfiguration
+        Loads the base configuration and alerting configuration.
         """
         self.alert_config = AlertConfigProvider(self.config.config_dir)
 

--- a/tests/configuration/test_provider.py
+++ b/tests/configuration/test_provider.py
@@ -42,3 +42,17 @@ class TestConfigProvider:
     def test_testconfig_uses_tmp(self, tmp_path, res):
         config = undertest.ConfigProvider(res / TEST_CONFIG)
         assert config.output_dir == tmp_path / "outputs"
+
+    @pytest.mark.parametrize(
+        "outputs, output_list",
+        [
+            (["Score2"], ["Score", "Score2"]),
+            (["Score"], ["Score"]),
+            (["Score2", "Score"], ["Score2", "Score"]),
+            (["Score1", "Score2"], ["Score", "Score1", "Score2"]),
+        ],
+    )
+    def test_provider_groups_primary_output_with_output_list(self, outputs, output_list):
+        config = undertest.ConfigProvider(BUILDER_CONFIG)
+        config.usage.outputs = outputs
+        assert config.output_list == output_list

--- a/tests/configuration/test_provider.py
+++ b/tests/configuration/test_provider.py
@@ -52,7 +52,7 @@ class TestConfigProvider:
             (["Score1", "Score2"], ["Score", "Score1", "Score2"]),
         ],
     )
-    def test_provider_groups_primary_output_with_output_list(self, outputs, output_list):
-        config = undertest.ConfigProvider(BUILDER_CONFIG)
+    def test_provider_groups_primary_output_with_output_list(self, outputs, output_list, res):
+        config = undertest.ConfigProvider(res / TEST_CONFIG)
         config.usage.outputs = outputs
         assert config.output_list == output_list

--- a/tests/controls/test_explore.py
+++ b/tests/controls/test_explore.py
@@ -1,15 +1,19 @@
+from unittest.mock import MagicMock, Mock, patch
+
 import ipywidgets
 import pytest
 
 import seismometer.controls.explore as undertest
+from seismometer import seismogram
 
 
+# region Test Base Classes
 class TestUpdatePlotWidget:
     def test_init(self):
         widget = undertest.UpdatePlotWidget()
         assert widget.plot_button.description == undertest.UpdatePlotWidget.UPDATE_PLOTS
         assert widget.plot_button.disabled is False
-        assert widget.code_checkbox.description == "show code"
+        assert widget.code_checkbox.description == widget.SHOW_CODE
         assert widget.show_code is False
 
     def test_plot_button_click(self):
@@ -57,6 +61,134 @@ class TestExplorationBaseClass:
 
         with pytest.raises(NotImplementedError):
             undertest.ExplorationWidget("ExploreTest", option_widget, lambda x: x)
+
+    @pytest.mark.parametrize(
+        "plot_module,plot_code",
+        [
+            ("__main__", "plot_something(False)"),
+            ("seismometer._api", "sm.plot_something(False)"),
+            ("something_else", "something_else.plot_something(False)"),
+        ],
+    )
+    def test_args_subclass(self, plot_module, plot_code):
+        option_widget = ipywidgets.Checkbox(description="ClickMe")
+        plot_function = Mock(return_value="some result")
+        plot_function.__name__ = "plot_something"
+        plot_function.__module__ = plot_module
+
+        class ExploreFake(undertest.ExplorationWidget):
+            def __init__(self):
+                super().__init__("Fake Explorer", option_widget, plot_function)
+
+            def generate_plot_args(self) -> tuple[tuple, dict]:
+                return [self.option_widget.value], {}
+
+        widget = ExploreFake()
+        assert widget.center.outputs[0]["data"]["text/plain"] == "'some result'"
+        plot_function.assert_called_once_with(False)
+        assert widget.current_plot_code == plot_code
+        assert widget.show_code is False
+
+    def test_kwargs_subclass(self):
+        option_widget = ipywidgets.Checkbox(description="ClickMe")
+        plot_function = Mock(return_value="some result")
+        plot_function.__name__ = "plot_something"
+        plot_function.__module__ = "test_explore"
+
+        class ExploreFake(undertest.ExplorationWidget):
+            def __init__(self):
+                super().__init__("Fake Explorer", option_widget, plot_function)
+
+            def generate_plot_args(self) -> tuple[tuple, dict]:
+                return [], {"checkbox": self.option_widget.value}
+
+        widget = ExploreFake()
+        assert widget.center.outputs[0]["data"]["text/plain"] == "'some result'"
+        plot_function.assert_called_once_with(checkbox=False)
+        assert widget.current_plot_code == "test_explore.plot_something(checkbox=False)"
+        assert widget.show_code is False
+
+    def test_args_kwargs_subclass(self):
+        option_widget = ipywidgets.Checkbox(description="ClickMe")
+        plot_function = Mock(return_value="some result")
+        plot_function.__name__ = "plot_something"
+        plot_function.__module__ = "test_explore"
+
+        class ExploreFake(undertest.ExplorationWidget):
+            def __init__(self):
+                super().__init__("Fake Explorer", option_widget, plot_function)
+
+            def generate_plot_args(self) -> tuple[tuple, dict]:
+                return ["test"], {"checkbox": self.option_widget.value}
+
+        widget = ExploreFake()
+        assert widget.center.outputs[0]["data"]["text/plain"] == "'some result'"
+        plot_function.assert_called_once_with("test", checkbox=False)
+        assert widget.current_plot_code == "test_explore.plot_something('test', checkbox=False)"
+        assert widget.show_code is False
+
+    def test_exception_plot_code_subclass(self):
+        option_widget = ipywidgets.Checkbox(description="ClickMe")
+
+        def plot_something(*args, **kwargs):
+            raise ValueError("Test Exception")
+
+        class ExploreFake(undertest.ExplorationWidget):
+            def __init__(self):
+                super().__init__("Fake Explorer", option_widget, plot_something)
+
+            def generate_plot_args(self) -> tuple[tuple, dict]:
+                return ["test"], {"checkbox": self.option_widget.value}
+
+        widget = ExploreFake()
+        assert "Traceback" in widget.center.outputs[0]["data"]["text/plain"]
+        assert "Test Exception" in widget.center.outputs[0]["data"]["text/plain"]
+
+    def test_no_initial_plot_subclass(self):
+        option_widget = ipywidgets.Checkbox(description="ClickMe")
+        plot_function = Mock(return_value="some result")
+        plot_function.__name__ = "plot_something"
+        plot_function.__module__ = "test_explore"
+
+        class ExploreFake(undertest.ExplorationWidget):
+            def __init__(self):
+                super().__init__("Fake Explorer", option_widget, plot_function, initial_plot=False)
+
+            def generate_plot_args(self) -> tuple[tuple, dict]:
+                return ["test"], {"checkbox": self.option_widget.value}
+
+        widget = ExploreFake()
+        widget.center.outputs == []
+        plot_function.assert_not_called()
+        assert widget.current_plot_code == ExploreFake.NO_CODE_STRING
+        assert widget.show_code is False
+
+    @pytest.mark.parametrize("show_code", [True, False])
+    def test_toggle_code_callback(self, show_code, capsys):
+        option_widget = ipywidgets.Checkbox(description="ClickMe")
+        plot_function = Mock(return_value="some result")
+        plot_function.__name__ = "plot_something"
+        plot_function.__module__ = "test_explore"
+
+        class ExploreFake(undertest.ExplorationWidget):
+            def __init__(self):
+                super().__init__("Fake Explorer", option_widget, plot_function)
+
+            def generate_plot_args(self) -> tuple[tuple, dict]:
+                return ["test"], {"checkbox": self.option_widget.value}
+
+        widget = ExploreFake()
+        widget.show_code = show_code
+        widget.code_output = MagicMock()
+        widget._on_plot_button_click()
+        stdout = capsys.readouterr().out
+        assert "some result" in stdout
+        code_in_output = "test_explore.plot_something" in stdout.split("\n")[-2]
+        assert code_in_output == show_code
+
+
+# endregion
+# region Test Model Options Widgets
 
 
 class TestModelOptionsWidget:
@@ -265,3 +397,238 @@ class TestModelFairnessAuditOptions:
         assert widget.fairness_slider.disabled
         assert widget.fairness_list.disabled
         assert widget.disabled
+
+
+class TestModelScoreComparisonOptionsWidget:
+    def test_init(self):
+        widget = undertest.ModelScoreComparisonOptionsWidget(
+            target_names=["T1", "T2"], score_names=["S1", "S2", "S3", "S4"]
+        )
+        assert len(widget.children) == 2
+        assert "Model Options" in widget.title.value
+        assert widget.target == "T1"
+        assert widget.scores == (
+            "S1",
+            "S2",
+        )
+
+    def test_disable(self):
+        widget = undertest.ModelScoreComparisonOptionsWidget(target_names=["T1", "T2"], score_names=["S1", "S2"])
+        widget.disabled = True
+        assert widget.target_list.disabled
+        assert widget.score_list.disabled
+        assert widget.disabled
+
+    def test_init_per_context(self):
+        widget = undertest.ModelScoreComparisonOptionsWidget(
+            target_names=["T1", "T2"], score_names=["S1", "S2", "S3", "S4"], per_context=True
+        )
+        assert len(widget.children) == 3
+        assert "Model Options" in widget.title.value
+        assert widget.target == "T1"
+        assert widget.scores == (
+            "S1",
+            "S2",
+        )
+        assert widget.group_scores is True
+
+    def test_disable_per_context(self):
+        widget = undertest.ModelScoreComparisonOptionsWidget(
+            target_names=["T1", "T2"], score_names=["S1", "S2"], per_context=False
+        )
+        assert widget.group_scores is False
+        widget.disabled = True
+        assert widget.target_list.disabled
+        assert widget.score_list.disabled
+        assert widget.per_context_checkbox.disabled
+        assert widget.disabled
+
+
+class TestModelTargetComparisonOptionsWidget:
+    def test_init(self):
+        widget = undertest.ModelTargetComparisonOptionsWidget(
+            target_names=["T1", "T2", "T3"], score_names=["S1", "S2"]
+        )
+        assert len(widget.children) == 2
+        assert "Model Options" in widget.title.value
+        assert widget.targets == (
+            "T1",
+            "T2",
+        )
+        assert widget.score == "S1"
+
+    def test_disable(self):
+        widget = undertest.ModelTargetComparisonOptionsWidget(target_names=["T1", "T2"], score_names=["S1", "S2"])
+        widget.disabled = True
+        assert widget.target_list.disabled
+        assert widget.score_list.disabled
+        assert widget.disabled
+
+    def test_init_per_context(self):
+        widget = undertest.ModelTargetComparisonOptionsWidget(
+            target_names=["T1", "T2", "T3"], score_names=["S1", "S2"], per_context=True
+        )
+        assert len(widget.children) == 3
+        assert "Model Options" in widget.title.value
+        assert widget.targets == (
+            "T1",
+            "T2",
+        )
+        assert widget.score == "S1"
+        assert widget.group_scores is True
+
+    def test_disable_per_context(self):
+        widget = undertest.ModelTargetComparisonOptionsWidget(
+            target_names=["T1", "T2"], score_names=["S1", "S2"], per_context=False
+        )
+        assert widget.group_scores is False
+        widget.disabled = True
+        assert widget.target_list.disabled
+        assert widget.score_list.disabled
+        assert widget.per_context_checkbox.disabled
+        assert widget.disabled
+
+
+class TestModelScoreComparisonAndCohortsWidget:
+    def test_init(self):
+        widget = undertest.ModelScoreComparisonAndCohortsWidget(
+            cohort_groups={"C1": ["C1.1", "C1.2"], "C2": ["C2.1", "C2.2"]},
+            target_names=["T1", "T2"],
+            score_names=["S1", "S2", "S3", "S4"],
+        )
+        assert len(widget.children) == 2
+        assert widget.cohorts == {}
+        assert widget.target == "T1"
+        assert widget.scores == (
+            "S1",
+            "S2",
+        )
+        assert widget.group_scores is False
+
+    def test_disable(self):
+        widget = undertest.ModelScoreComparisonAndCohortsWidget(
+            cohort_groups={"C1": ["C1.1", "C1.2"], "C2": ["C2.1", "C2.2"]},
+            target_names=["T1", "T2"],
+            score_names=["S1", "S2"],
+        )
+        widget.disabled = True
+        assert widget.model_options.disabled
+        assert widget.cohort_list.disabled
+        assert widget.disabled
+
+
+class TestModelTargetComparisonAndCohortsWidget:
+    def test_init(self):
+        widget = undertest.ModelTargetComparisonAndCohortsWidget(
+            cohort_groups={"C1": ["C1.1", "C1.2"], "C2": ["C2.1", "C2.2"]},
+            target_names=["T1", "T2", "T3"],
+            score_names=["S1", "S2"],
+        )
+        assert len(widget.children) == 2
+        assert widget.cohorts == {}
+        assert widget.targets == (
+            "T1",
+            "T2",
+        )
+        assert widget.score == "S1"
+        assert widget.group_scores is False
+
+    def test_disable(self):
+        widget = undertest.ModelTargetComparisonAndCohortsWidget(
+            cohort_groups={"C1": ["C1.1", "C1.2"], "C2": ["C2.1", "C2.2"]},
+            target_names=["T1", "T2"],
+            score_names=["S1", "S2"],
+        )
+        widget.disabled = True
+        assert widget.model_options.disabled
+        assert widget.cohort_list.disabled
+        assert widget.disabled
+
+
+# endregion
+# region Test Exploration Widgets
+class TestExplorationSubpopulationWidget:
+    @patch.object(seismogram, "Seismogram", return_value=Mock())
+    def test_init(self, mock_seismo):
+        fake_seismo = mock_seismo()
+        fake_seismo.available_cohort_groups = {"C1": ["C1.1", "C1.2"], "C2": ["C2.1", "C2.2"]}
+        plot_function = Mock(return_value="some result")
+        plot_function.__name__ = "plot_function"
+        plot_function.__module__ = "test_explore"
+
+        widget = undertest.ExplorationSubpopulationWidget(title="Subpopulation", plot_function=plot_function)
+
+        assert widget.disabled is False
+        assert widget.update_plot_widget.disabled
+        assert widget.current_plot_code == "test_explore.plot_function({})"
+        plot_function.assert_called_once_with({})  # default value
+
+    @patch.object(seismogram, "Seismogram", return_value=Mock())
+    def test_option_update(self, mock_seismo):
+        fake_seismo = mock_seismo()
+        fake_seismo.available_cohort_groups = {"C1": ["C1.1", "C1.2"], "C2": ["C2.1", "C2.2"]}
+        plot_function = Mock(return_value="some result")
+        plot_function.__name__ = "plot_function"
+        plot_function.__module__ = "test_explore"
+
+        widget = undertest.ExplorationSubpopulationWidget(title="Subpopulation", plot_function=plot_function)
+
+        widget.option_widget.value = {
+            "C2": [
+                "C2.1",
+            ]
+        }
+        widget.update_plot()
+        plot_function.assert_called_with(
+            {
+                "C2": [
+                    "C2.1",
+                ]
+            }
+        )  # updated value
+
+
+class TestExplorationModelSubgroupEvaluationWidget:
+    @patch.object(seismogram, "Seismogram", return_value=Mock())
+    def test_init(self, mock_seismo):
+        fake_seismo = mock_seismo()
+        fake_seismo.available_cohort_groups = {"C1": ["C1.1", "C1.2"], "C2": ["C2.1", "C2.2"]}
+        fake_seismo.thresholds = [0.1, 0.2]
+        fake_seismo.target_cols = ["T1", "T2"]
+        fake_seismo.output_list = ["S1", "S2"]
+
+        plot_function = Mock(return_value="some result")
+        plot_function.__name__ = "plot_function"
+        plot_function.__module__ = "test_explore"
+
+        widget = undertest.ExplorationModelSubgroupEvaluationWidget(
+            title="Unit Test Title", plot_function=plot_function
+        )
+
+        assert widget.disabled is False
+        assert widget.update_plot_widget.disabled
+        assert widget.current_plot_code == "test_explore.plot_function({}, 'T1', 'S1', [0.2, 0.1], per_context=False)"
+        plot_function.assert_called_once_with({}, "T1", "S1", [0.2, 0.1], per_context=False)  # default value
+
+    @patch.object(seismogram, "Seismogram", return_value=Mock())
+    def test_option_update(self, mock_seismo):
+        fake_seismo = mock_seismo()
+        fake_seismo.available_cohort_groups = {"C1": ["C1.1", "C1.2"], "C2": ["C2.1", "C2.2"]}
+        fake_seismo.thresholds = [0.1, 0.2]
+        fake_seismo.target_cols = ["T1", "T2"]
+        fake_seismo.output_list = ["S1", "S2"]
+
+        plot_function = Mock(return_value="some result")
+        plot_function.__name__ = "plot_function"
+        plot_function.__module__ = "test_explore"
+
+        widget = undertest.ExplorationModelSubgroupEvaluationWidget(
+            title="Unit Test Title", plot_function=plot_function
+        )
+
+        widget.option_widget.cohort_list.value = {"C2": ("C2.1",)}
+        widget.update_plot()
+        plot_function.assert_called_with({"C2": ("C2.1",)}, "T1", "S1", [0.2, 0.1], per_context=False)  # updated value
+
+
+# endregion

--- a/tests/controls/test_selection.py
+++ b/tests/controls/test_selection.py
@@ -1,3 +1,5 @@
+import pytest
+
 import seismometer.controls.selection as undertest
 
 
@@ -48,24 +50,30 @@ class TestSelectionListWidget:
         assert not widget.button_from_option["c"].disabled
 
 
+@pytest.mark.parametrize("show_all", [True, False])
 class TestMultiSelectionListWidget:
-    def test_init(self):
+    def test_init(self, show_all):
         widget = undertest.MultiSelectionListWidget(
             options={"a": ["a", "b", "c"], "b": ["a", "c"]},
             values={"a": ["a", "b"], "b": ["c"]},
             title="title",
             border=True,
+            show_all=show_all,
         )
         assert widget.title == "title"
         assert widget.value == {"a": ("a", "b"), "b": ("c",)}
 
-    def test_init_no_value(self):
-        widget = undertest.MultiSelectionListWidget(options={"a": ["a", "b", "c"], "b": ["a", "c"]})
+    def test_init_no_value(self, show_all):
+        widget = undertest.MultiSelectionListWidget(
+            options={"a": ["a", "b", "c"], "b": ["a", "c"]},
+            show_all=show_all,
+        )
         assert widget.value == {}
 
-    def test_value_propagation(self):
+    def test_value_propagation(self, show_all):
         widget = undertest.MultiSelectionListWidget(
             options={"a": ["a", "b", "c"], "b": ["a", "c"], "d": ["a", "b", "c"]},
+            show_all=show_all,
         )
         assert widget.value == {}
         widget.value = {"a": ("a", "b"), "b": ("c",)}
@@ -73,9 +81,10 @@ class TestMultiSelectionListWidget:
         assert widget.selection_widgets["b"].value == ("c",)
         assert widget.selection_widgets["d"].value == ()
 
-    def test_on_subselection_changed(self):
+    def test_on_subselection_changed(self, show_all):
         widget = undertest.MultiSelectionListWidget(
             options={"a": ["a", "b", "c"], "b": ["a", "c"], "d": ["a", "b", "c"]},
+            show_all=show_all,
         )
         assert widget.value == {}
         widget.selection_widgets["a"].value = ("a", "b")
@@ -83,18 +92,20 @@ class TestMultiSelectionListWidget:
         assert widget.selection_widgets["b"].value == ()
         assert widget.selection_widgets["d"].value == ()
 
-    def test_display_text(self):
+    def test_display_text(self, show_all):
         widget = undertest.MultiSelectionListWidget(
             options={"a": ["a", "b", "c"], "b": ["a", "c"], "d": ["a", "b", "c"]},
+            show_all=show_all,
         )
         assert widget.value == {}
         assert widget.get_selection_text() == ""
         widget.value = {"a": ("a", "b"), "b": ("c",)}
         assert widget.get_selection_text() == "a: a, b\nb: c"
 
-    def test_disabled(self):
+    def test_disabled(self, show_all):
         widget = undertest.MultiSelectionListWidget(
             options={"a": ["a", "b", "c"], "b": ["a", "c"], "d": ["a", "b", "c"]},
+            show_all=show_all,
         )
         assert not widget.disabled
         widget.disabled = True
@@ -176,3 +187,62 @@ class TestDisjointSelectionListsWidget:
         assert not widget.dropdown.disabled
         assert not widget.selection_widgets["a"].disabled
         assert not widget.selection_widgets["b"].disabled
+
+
+class TestMultiselectDropdownWidget:
+    def test_init(self):
+        widget = undertest.MultiselectDropdownWidget(options=["a", "b", "c"], value=["a", "b"], title="title")
+        assert widget.title == "title"
+        assert widget.value == ("a", "b")
+        assert widget.get_selection_text() == "title: a, b"
+
+    def test_init_no_value(self):
+        widget = undertest.MultiselectDropdownWidget(options=["a", "b", "c"])
+        assert widget.title is None
+        assert widget.value == ()
+        assert widget.get_selection_text() == ""
+
+    def test_add_all(self):
+        widget = undertest.MultiselectDropdownWidget(options=["a", "b", "c"])
+        widget.dropdown.value = -1
+        assert widget.value == ("a", "b", "c")
+        assert widget.dropdown.value == -2  # reset to default
+
+    def test_value_propagation(self):
+        widget = undertest.MultiselectDropdownWidget(options=["a", "b", "c"])
+        widget.value = ("a", "b")
+        assert len(widget.selection_options.children) == 2
+        assert widget.selection_options.children[0].description == "a"
+        assert widget.selection_options.children[1].description == "b"
+
+    def test_value_propagation_remove_option(self):
+        widget = undertest.MultiselectDropdownWidget(options=["a", "b", "c"], value=["a", "b"], title="title")
+        assert widget.title == "title"
+        widget.selection_options.children[0].click()
+        assert widget.value == ("b",)
+
+    def test_dropdown_changes_value(self):
+        widget = undertest.MultiselectDropdownWidget(options=["a", "b", "c"])
+        widget.dropdown.value = 1  # index of b
+        assert widget.value == ("b",)
+        widget.dropdown.value = 2  # index of c
+        assert widget.value == (
+            "b",
+            "c",
+        )
+        widget.dropdown.value = 0  # index of a
+        assert widget.value == (
+            "a",
+            "b",
+            "c",
+        )
+
+    def test_disabled(self):
+        widget = undertest.MultiselectDropdownWidget(options=["a", "b", "c"])
+        assert not widget.disabled
+        widget.disabled = True
+        assert widget.disabled
+        assert widget.dropdown.disabled
+        widget.disabled = False
+        assert not widget.disabled
+        assert not widget.dropdown.disabled


### PR DESCRIPTION
# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->

## Description of changes
<!-- Describe your changes and any implementation decisions -->
<!-- Especially for enhancements, start conversations early. Ideally in the documenting issue -->
<!-- Can be formatted as a checklist for reviewers. -->

Adds more support for multiple targets and multiple scores, as well as larger cohort lists

1. Larger cohort lists - Moved list selection to allow dropdowns an tags that can be dismissed. 
![image](https://github.com/user-attachments/assets/3441beb7-8e6d-4d62-9f2f-1cdd6b7e6773)

2. Compare two or more targets for the same score - Re-uses the 5 plots for cohort group comparisons to give a direct comparison of how well a score works for different targets

![image](https://github.com/user-attachments/assets/a290f352-579c-4576-92f0-de3c620d3d29)

3. Compare two or more scores for the same target - Re-uses the 5 plots for cohort group comparisons to give a direct comparison between multiple scores for the same target

![image](https://github.com/user-attachments/assets/409195c9-a2cd-45cd-91c9-914c879e41a2)

4. Includes the code from https://github.com/epic-open-source/seismometer/pull/80 as a new sm.ExploreSubgroups() control. 

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
