### PR TITLE
Cast inferred label to data type of label column

### DIFF
--- a/changelog/87.bugfix.rst
+++ b/changelog/87.bugfix.rst
@@ -1,0 +1,1 @@
+Cast inferred label to same type as the label column when inferring labels. 

--- a/src/seismometer/data/pandas_helpers.py
+++ b/src/seismometer/data/pandas_helpers.py
@@ -152,7 +152,9 @@ def merge_windowed_event(
 
     # refactor to generalize
     if merge_strategy == "forward":  # For forward merges, don't count events that happen before the prediction
-        predictions.loc[predictions[predtime_col] > predictions[r_ref], event_val_col] = -1
+        predictions.loc[predictions[predtime_col] > predictions[r_ref], event_val_col] = predictions[
+            event_val_col
+        ].dtype.type(-1)
 
     return predictions.drop(columns=r_ref)
 

--- a/src/seismometer/data/pandas_helpers.py
+++ b/src/seismometer/data/pandas_helpers.py
@@ -201,12 +201,14 @@ def infer_label(
     except BaseException:  # Leave as nonnumeric
         pass
 
-    label_na_map = dataframe[label_col].isna()
     time_na_map = dataframe[time_col].isna()
-    dataframe.loc[(label_na_map & ~time_na_map), label_col] = (
-        impute_val or 1
+    dataframe.loc[~time_na_map, label_col] = dataframe.loc[~time_na_map, label_col]\
+    .fillna(
+        (impute_val or dataframe[label_col].dtype.type(1)),
     )  # Impute value if time exists but label is missing
-    dataframe.loc[dataframe[label_col].isna(), label_col] = 0  # Set label to 0 if time and label are both missing
+
+    # Set label to 0 if time and label are both missing
+    dataframe[label_col].fillna(dataframe[label_col].dtype.type(0), inplace=True) 
 
     return dataframe
 

--- a/src/seismometer/data/pandas_helpers.py
+++ b/src/seismometer/data/pandas_helpers.py
@@ -202,13 +202,12 @@ def infer_label(
         pass
 
     time_na_map = dataframe[time_col].isna()
-    dataframe.loc[~time_na_map, label_col] = dataframe.loc[~time_na_map, label_col]\
-    .fillna(
+    dataframe.loc[~time_na_map, label_col] = dataframe.loc[~time_na_map, label_col].fillna(
         (impute_val or dataframe[label_col].dtype.type(1)),
     )  # Impute value if time exists but label is missing
 
     # Set label to 0 if time and label are both missing
-    dataframe[label_col].fillna(dataframe[label_col].dtype.type(0), inplace=True) 
+    dataframe[label_col].fillna(dataframe[label_col].dtype.type(0), inplace=True)
 
     return dataframe
 


### PR DESCRIPTION
# Overview
Prevents errors around trying to set ints in incompatible columns.  

## Description of changes
Cast the int values to be the same value as the label column in infer_label.

## Author Checklist
- [x] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [x] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
