### PR TITLE
Remove datatime columns for ydata-profiling update in 4.10

### DIFF
--- a/changelog/88.bugfix.rst
+++ b/changelog/88.bugfix.rst
@@ -1,0 +1,1 @@
+Exclude time columns from ydata-profiling.

--- a/src/seismometer/_api.py
+++ b/src/seismometer/_api.py
@@ -130,7 +130,8 @@ def target_feature_summary(exclude_cols: list[str] = None, inline=False):
     """
     sg = Seismogram()
 
-    exclude_cols = exclude_cols or sg.entity_keys
+    exclude_cols = exclude_cols or [key for key in sg.entity_keys]
+    exclude_cols += [pdh.event_time(event.display_name) for event in sg.config.events.values()]
     positive_target = FilterRule.eq(sg.target, 1)
     negative_target = ~positive_target
 

--- a/src/seismometer/_api.py
+++ b/src/seismometer/_api.py
@@ -131,7 +131,7 @@ def target_feature_summary(exclude_cols: list[str] = None, inline=False):
     sg = Seismogram()
 
     exclude_cols = exclude_cols or [key for key in sg.entity_keys]
-    exclude_cols += [pdh.event_time(event.display_name) for event in sg.config.events.values()]
+    exclude_cols += sg.dataframe.select_dtypes(include=["datetime", "datetimetz"]).columns.tolist()
     positive_target = FilterRule.eq(sg.target, 1)
     negative_target = ~positive_target
 

--- a/src/seismometer/_api.py
+++ b/src/seismometer/_api.py
@@ -131,7 +131,7 @@ def target_feature_summary(exclude_cols: list[str] = None, inline=False):
     sg = Seismogram()
 
     exclude_cols = exclude_cols or [key for key in sg.entity_keys]
-    exclude_cols += sg.dataframe.select_dtypes(include=["datetime", "datetimetz"]).columns.tolist()
+    exclude_cols += sg.dataframe.select_dtypes(include=["datetime", "datetimetz", "datetime64[ns]"]).columns.tolist()
     positive_target = FilterRule.eq(sg.target, 1)
     negative_target = ~positive_target
 

--- a/src/seismometer/_api.py
+++ b/src/seismometer/_api.py
@@ -130,8 +130,7 @@ def target_feature_summary(exclude_cols: list[str] = None, inline=False):
     """
     sg = Seismogram()
 
-    exclude_cols = exclude_cols or [key for key in sg.entity_keys]
-    exclude_cols += sg.dataframe.select_dtypes(include=["datetime", "datetimetz", "datetime64[ns]"]).columns.tolist()
+    exclude_cols = exclude_cols or sg.entity_keys
     positive_target = FilterRule.eq(sg.target, 1)
     negative_target = ~positive_target
 

--- a/src/seismometer/report/profiling.py
+++ b/src/seismometer/report/profiling.py
@@ -20,6 +20,22 @@ from .alerting import AlertConfigProvider, ParsedAlert, ParsedAlertList
 PROFILING_CONFIG_PATH = _files(seismometer.report) / "report_config.yml"
 logger = logging.getLogger("seismometer")
 
+def filter_unsupported_columns(df: DataFrame) -> DataFrame:
+    """
+    Filters out columns that are not supported by ydata-profiling.
+
+    Parameters
+    ----------
+    df : DataFrame
+        A Pandas DataFrame object.
+
+    Returns
+    -------
+    DataFrame
+        A Pandas DataFrame object with unsupported columns removed.
+    """
+    return df.select_dtypes(exclude=["datetime", "datetimetz", "datetime64[ns]"])
+
 
 class ReportWrapper(ABC):
     _df: DataFrame
@@ -85,8 +101,8 @@ class ComparisonReportWrapper(ReportWrapper):
             Base title for the report, by default "Feature Report".
         """
 
-        self._l_df = l_df
-        self._r_df = r_df
+        self._l_df = filter_unsupported_columns(l_df)
+        self._r_df = filter_unsupported_columns(r_df)
         self._l_title = l_title
         self._r_title = r_title
         self._exclude_cols = exclude_cols
@@ -149,7 +165,7 @@ class SingleReportWrapper(ReportWrapper):
         alert_config : Optional[AlertConfigProvider], optional
             The parsed configuration for determining which alerts are shown, by default None.
         """
-        self._df = df
+        self._df = filter_unsupported_columns(df)
         self._title = title
         self._html_path = output_path / (slugify(title) + ".html")
         self._alert_path = output_path / (slugify(title) + "_alerts.json")

--- a/src/seismometer/report/profiling.py
+++ b/src/seismometer/report/profiling.py
@@ -20,6 +20,7 @@ from .alerting import AlertConfigProvider, ParsedAlert, ParsedAlertList
 PROFILING_CONFIG_PATH = _files(seismometer.report) / "report_config.yml"
 logger = logging.getLogger("seismometer")
 
+
 def filter_unsupported_columns(df: DataFrame) -> DataFrame:
     """
     Filters out columns that are not supported by ydata-profiling.


### PR DESCRIPTION
# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->

## Description of changes
Fixes issue with ydata-profiling 4.10.0 update that now enforces some data type restrictions. 

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
