### PR TITLE
Respect dictionary datatyping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ ENV/
 /output/
 /notebooks/output/
 /notebooks/data/
-example-notebooks/binary-classifier/dictionary.yml
+example-notebooks/binary-classifier/data_dictionary.yml
 example-notebooks/binary-classifier/data/*
 example-notebooks/binary-classifier/outputs/*
 

--- a/changelog/92.feature.rst
+++ b/changelog/92.feature.rst
@@ -1,0 +1,1 @@
+Cast features and event _Value columns to dtypes in the dictionary yml when specified in the dictionary configuration.

--- a/changelog/92.feature.rst
+++ b/changelog/92.feature.rst
@@ -1,1 +1,2 @@
-Cast features and event _Value columns to dtypes in the dictionary yml when specified in the dictionary configuration.
+Cast features to dtypes in the dictionary yml when specified in the dictionary configuration.
+Cast event _Values to dtypes in the dictionary yml when specified in the dictionary configuration, done after imputation.

--- a/changelog/XX.feature.rst
+++ b/changelog/XX.feature.rst
@@ -1,0 +1,1 @@
+Cast features and event _Value columns to dtypes in the dictionary yml when configured.

--- a/changelog/XX.feature.rst
+++ b/changelog/XX.feature.rst
@@ -1,1 +1,0 @@
-Cast features and event _Value columns to dtypes in the dictionary yml when configured.

--- a/docs/reference/internals.rst
+++ b/docs/reference/internals.rst
@@ -97,6 +97,7 @@ Seismogram Loaders
    loader.event.merge_onto_predictions
    loader.prediction.parquet_loader
    loader.prediction.assumed_types
+   loader.prediction.dictionary_types
 
 Summaries
 ~~~~~~~~~

--- a/docs/reference/internals.rst
+++ b/docs/reference/internals.rst
@@ -68,6 +68,7 @@ Pandas Helpers
    pandas_helpers.post_process_event
    pandas_helpers.merge_windowed_event
    pandas_helpers.valid_event
+   pandas_helpers.try_casting
 
 Performance
 ~~~~~~~~~~~

--- a/docs/reference/internals.rst
+++ b/docs/reference/internals.rst
@@ -65,7 +65,7 @@ Pandas Helpers
    pandas_helpers.event_score
    pandas_helpers.event_time
    pandas_helpers.event_value
-   pandas_helpers.infer_label
+   pandas_helpers.post_process_event
    pandas_helpers.merge_windowed_event
    pandas_helpers.valid_event
 

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -367,7 +367,9 @@ is not strictly required.
         display_name: 30 days readmission
         definition: |
            A binary indicator of whether the diabetes patient was readmitted within 30 days of discharge
-        dtype: bool
+        dtype: int
+
+Note that even with a binary event, it is generally more convenient to use an int or even float datatype.
 
 Create Usage Configuration
 --------------------------

--- a/example-notebooks/binary-classifier/classifier_bin.ipynb
+++ b/example-notebooks/binary-classifier/classifier_bin.ipynb
@@ -92,7 +92,7 @@
     "DATASET_SOURCE = \"https://raw.githubusercontent.com/epic-open-source/seismometer-data/main\"\n",
     "_ = urllib.request.urlretrieve(f\"{DATASET_SOURCE}/diabetes/predictions.parquet\", \"data/predictions.parquet\")\n",
     "_ = urllib.request.urlretrieve(f\"{DATASET_SOURCE}/diabetes/events.parquet\", \"data/events.parquet\")\n",
-    "_ = urllib.request.urlretrieve(f\"{DATASET_SOURCE}/diabetes/data_dictionary.yml\", \"dictionary.yml\")\n",
+    "_ = urllib.request.urlretrieve(f\"{DATASET_SOURCE}/diabetes/data_dictionary.yml\", \"data_dictionary.yml\")\n",
     "# We assume the existence of the following files in the same directory as the notebook: config.yml, usage_config.yml and data/metadata.json"
    ]
   },

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ all =
     %(docs)s
     %(audit)s
 audit =
-    aequitas>=1.0.0,<2
+    aequitas @ https://files.pythonhosted.org/packages/29/c3/bde85e8425bef56825f83fe0cd2fced38a3afdd5dd8b72e41ed3d15edf18/aequitas-1.0.0-1-py3-none-any.whl
     vl-convert-python>=1.5.0,<2
 dev =
     %(audit)s

--- a/src/seismometer/configuration/__init__.py
+++ b/src/seismometer/configuration/__init__.py
@@ -1,2 +1,8 @@
 from .config import ConfigProvider
 from .model import AggregationStrategies, MergeStrategies
+
+
+class ConfigurationError(Exception):
+    """Raised when a configuration error is detected."""
+
+    pass

--- a/src/seismometer/configuration/config.py
+++ b/src/seismometer/configuration/config.py
@@ -57,6 +57,8 @@ class ConfigProvider:
         self._events: EventDictionary = None
         self._output_dir: Path = None
         self._output_notebook: str = ""
+        self._event_defs: EventDictionary = None
+        self._prediction_defs: PredictionDictionary = None
 
         if definitions is not None:
             self._prediction_defs = PredictionDictionary(predictions=definitions.pop("predictions", []))
@@ -144,7 +146,9 @@ class ConfigProvider:
 
     def _load_definitions(self, def_path: Path, def_key: str, data_model: BaseModel) -> dict:
         raw_defs = load_yaml(def_path, resource_dir=self.config_dir)
-        return data_model(**raw_defs.pop(def_key, {}))
+        if raw_defs is None:
+            raw_defs = {def_key: []}
+        return data_model(**raw_defs)
 
     @property
     def usage(self) -> DataUsage:

--- a/src/seismometer/configuration/config.py
+++ b/src/seismometer/configuration/config.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -145,7 +146,12 @@ class ConfigProvider:
         return self._event_defs
 
     def _load_definitions(self, def_path: Path, def_key: str, data_model: BaseModel) -> dict:
-        raw_defs = load_yaml(def_path, resource_dir=self.config_dir)
+        try:
+            raw_defs = load_yaml(def_path, resource_dir=self.config_dir)
+        except FileNotFoundError:
+            logging.info(f"No dictionary file found at {def_path}. Update config config.")
+            raw_defs = None
+
         if raw_defs is None:
             raw_defs = {def_key: []}
         return data_model(**raw_defs)

--- a/src/seismometer/configuration/config.py
+++ b/src/seismometer/configuration/config.py
@@ -54,8 +54,6 @@ class ConfigProvider:
     ):
         self._config: OtherInfo = None
         self._usage: DataUsage = None
-        self._predictions: PredictionDictionary = None
-        self._events: EventDictionary = None
         self._output_dir: Path = None
         self._output_notebook: str = ""
         self._event_defs: EventDictionary = None

--- a/src/seismometer/configuration/model.py
+++ b/src/seismometer/configuration/model.py
@@ -113,7 +113,7 @@ class PredictionDictionary(BaseModel):
         -------
         The DictionaryItem with name specified or the default value
         """
-        return _search_dictionary(self.predictions, key) or default
+        return self[key] or default
 
 
 class EventDictionary(BaseModel):
@@ -160,7 +160,7 @@ class EventDictionary(BaseModel):
         -------
         The DictionaryItem with name specified or the default value
         """
-        return _search_dictionary(self.predictions, key) or default
+        return self[key] or default
 
 
 class Cohort(BaseModel):

--- a/src/seismometer/configuration/model.py
+++ b/src/seismometer/configuration/model.py
@@ -79,8 +79,24 @@ class PredictionDictionary(BaseModel):
 
     """
 
-    predictions: list[DictionaryItem]
+    predictions: list[DictionaryItem] = []
     """ The list of all columns in the predictions data."""
+
+    def __getitem__(self, key: str) -> Optional[DictionaryItem]:
+        """
+        Get the definition of an item.
+
+        Parameters
+        ----------
+        key : str
+            The column name.
+
+        Returns
+        -------
+        Optional[str]
+            The definition of the column.
+        """
+        return _search_dictionary(self.predictions, key)
 
 
 class EventDictionary(BaseModel):
@@ -92,8 +108,25 @@ class EventDictionary(BaseModel):
     interventions, and outcomes.
     """
 
-    events: list[DictionaryItem]
+    events: list[DictionaryItem] = []
+
     """ The list of all columns in the events data."""
+
+    def __getitem__(self, key: str) -> Optional[DictionaryItem]:
+        """
+        Get the definition of an item.
+
+        Parameters
+        ----------
+        key : str
+            The column name.
+
+        Returns
+        -------
+        Optional[str]
+            The definition of the column.
+        """
+        return _search_dictionary(self.events, key)
 
 
 class Cohort(BaseModel):
@@ -353,3 +386,10 @@ class DataUsage(BaseModel):
             seen_names.add(feature.display_name)
             good_features.append(feature)
         return good_features
+
+
+def _search_dictionary(dictionary: list[DictionaryItem], key: str) -> Optional[DictionaryItem]:
+    for item in dictionary:
+        if item.name == key:
+            return item
+    return

--- a/src/seismometer/configuration/model.py
+++ b/src/seismometer/configuration/model.py
@@ -113,7 +113,10 @@ class PredictionDictionary(BaseModel):
         -------
         The DictionaryItem with name specified or the default value
         """
-        return self[key] or default
+        try:
+            return self[key]
+        except KeyError:
+            return default
 
 
 class EventDictionary(BaseModel):
@@ -160,7 +163,10 @@ class EventDictionary(BaseModel):
         -------
         The DictionaryItem with name specified or the default value
         """
-        return self[key] or default
+        try:
+            return self[key]
+        except KeyError:
+            return default
 
 
 class Cohort(BaseModel):
@@ -426,4 +432,4 @@ def _search_dictionary(dictionary: list[DictionaryItem], key: str) -> Optional[D
     for item in dictionary:
         if item.name == key:
             return item
-    return
+    raise KeyError(f"{key} not found")

--- a/src/seismometer/configuration/model.py
+++ b/src/seismometer/configuration/model.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -98,6 +98,23 @@ class PredictionDictionary(BaseModel):
         """
         return _search_dictionary(self.predictions, key)
 
+    def get(self, key: str, default: Optional[Any] = None) -> Union[DictionaryItem, Any]:
+        """
+        Get the definition of an item.
+
+        Parameters
+        ----------
+        key : str
+            The column name.
+        default : Optional[Any]
+            The default value to return if the key is not found, defaults to None.
+
+        Returns
+        -------
+        The DictionaryItem with name specified or the default value
+        """
+        return _search_dictionary(self.predictions, key) or default
+
 
 class EventDictionary(BaseModel):
     """
@@ -127,6 +144,23 @@ class EventDictionary(BaseModel):
             The definition of the column.
         """
         return _search_dictionary(self.events, key)
+
+    def get(self, key: str, default: Optional[Any] = None) -> Union[DictionaryItem, Any]:
+        """
+        Get the definition of an item.
+
+        Parameters
+        ----------
+        key : str
+            The column name.
+        default : Optional[Any]
+            The default value to return if the key is not found, defaults to None.
+
+        Returns
+        -------
+        The DictionaryItem with name specified or the default value
+        """
+        return _search_dictionary(self.predictions, key) or default
 
 
 class Cohort(BaseModel):

--- a/src/seismometer/data/loader/__init__.py
+++ b/src/seismometer/data/loader/__init__.py
@@ -29,7 +29,7 @@ def loader_factory(config: ConfigProvider, post_load_fn: ConfigFrameHook = None)
     return SeismogramLoader(
         config,
         prediction_fn=prediction_loader,
-        post_predict_fn=prediction.assumed_types,
+        post_predict_fn=prediction.dictionary_types,
         event_fn=event_loader,
         post_event_fn=event.post_transform_fn,
         merge_fn=event.merge_onto_predictions,

--- a/src/seismometer/data/loader/event.py
+++ b/src/seismometer/data/loader/event.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 import seismometer.data.pandas_helpers as pdh
 from seismometer.configuration import ConfigProvider
+from seismometer.configuration.model import Event
 
 logger = logging.getLogger("seismometer")
 
@@ -88,6 +89,9 @@ def merge_onto_predictions(config: ConfigProvider, event_frame: pd.DataFrame, da
     event_frame = event_frame.sort_values("Time", kind="mergesort")
 
     for one_event in config.events.values():
+        # Get dtype
+        event_dtype = _get_source_type(config, one_event)
+
         # Merge
         if one_event.window_hr:
             logger.debug(
@@ -99,6 +103,7 @@ def merge_onto_predictions(config: ConfigProvider, event_frame: pd.DataFrame, da
                 one_event.source,
                 dataframe,
                 event_frame,
+                event_dtype=event_dtype,
                 window_hrs=one_event.window_hr,
                 offset_hrs=one_event.offset_hr,
                 display=one_event.display_name,
@@ -112,6 +117,7 @@ def merge_onto_predictions(config: ConfigProvider, event_frame: pd.DataFrame, da
                 one_event.source,
                 dataframe,
                 event_frame,
+                event_dtype=event_dtype,
                 display=one_event.display_name,
                 sort=False,
                 impute_val=one_event.impute_val,
@@ -119,11 +125,11 @@ def merge_onto_predictions(config: ConfigProvider, event_frame: pd.DataFrame, da
 
         # Impute no event
         if one_event.impute_val and one_event.impute_val != 0:
+            event_val = pdh.event_value(one_event.display_name)
             logger.warning(
                 f"Event {one_event.display_name} specified impute; "
                 + "currently missing event value is being inferred based on timestamp existence."
             )
-            event_val = pdh.event_value(one_event.display_name)
             impute = one_event.impute_val
             dataframe[event_val] = dataframe[event_val].fillna(impute)
 
@@ -135,6 +141,7 @@ def _merge_event(
     event_cols,
     dataframe,
     event_frame,
+    event_dtype=None,
     offset_hrs=0,
     window_hrs=None,
     display="",
@@ -153,7 +160,32 @@ def _merge_event(
         min_leadtime_hrs=offset_hrs,
         window_hrs=window_hrs,
         event_base_time_col="Time",
+        event_base_val_dtype=event_dtype,
         sort=sort,
         merge_strategy=config.events[disp_event].merge_strategy,
         impute_val=impute_val,
     )
+
+
+def _get_source_type(config: ConfigProvider, event: Event):
+    dtype = None
+    multitypes = set()  # Aggregate woarning messages
+    for source in event.source:
+        source_defn = config.event_defs[source]
+        new_type = getattr(source_defn, "dtype", None)
+        if new_type is None:
+            continue
+        if dtype is None:
+            dtype = new_type
+            continue
+
+        if dtype != new_type:
+            multitypes.add(new_type)
+
+    if len(multitypes) > 1:
+        logger.warning(
+            f"Multiple types found for event {event.display_name}. "
+            + f"Will use the first source of type {dtype} and ignore others: {','.join(multitypes)}"
+        )
+
+    return dtype

--- a/src/seismometer/data/loader/event.py
+++ b/src/seismometer/data/loader/event.py
@@ -172,8 +172,10 @@ def _get_source_type(config: ConfigProvider, event: Event) -> str:
     dtype = None
     multitypes = set()  # Aggregate woarning messages
     for source in event.source:
-        source_defn = config.event_defs.get(source, None)
-        new_type = getattr(source_defn, "dtype", None)
+        new_type = None
+        if (source_defn := config.event_defs.get(source, None)) is not None:
+            new_type = source_defn.dtype
+
         if new_type is None:
             continue
         if dtype is None:

--- a/src/seismometer/data/loader/event.py
+++ b/src/seismometer/data/loader/event.py
@@ -167,11 +167,12 @@ def _merge_event(
     )
 
 
-def _get_source_type(config: ConfigProvider, event: Event):
+def _get_source_type(config: ConfigProvider, event: Event) -> str:
+    """Get the dtype of the first source of the specified event."""
     dtype = None
     multitypes = set()  # Aggregate woarning messages
     for source in event.source:
-        source_defn = config.event_defs[source]
+        source_defn = config.event_defs.get(source, None)
         new_type = getattr(source_defn, "dtype", None)
         if new_type is None:
             continue

--- a/src/seismometer/data/loader/event.py
+++ b/src/seismometer/data/loader/event.py
@@ -108,7 +108,7 @@ def merge_onto_predictions(config: ConfigProvider, event_frame: pd.DataFrame, da
                 offset_hrs=one_event.offset_hr,
                 display=one_event.display_name,
                 sort=False,
-                impute_val=one_event.impute_val,
+                impute_pos=one_event.impute_val,
             )
         else:  # No lookback
             logger.debug(f"Merging event {one_event.display_name}")
@@ -120,7 +120,7 @@ def merge_onto_predictions(config: ConfigProvider, event_frame: pd.DataFrame, da
                 event_dtype=event_dtype,
                 display=one_event.display_name,
                 sort=False,
-                impute_val=one_event.impute_val,
+                impute_pos=one_event.impute_val,
             )
 
         # Impute no event
@@ -146,7 +146,8 @@ def _merge_event(
     window_hrs=None,
     display="",
     sort=True,
-    impute_val=None,
+    impute_pos=1,
+    impute_neg=0,
 ) -> pd.DataFrame:
     """Wrapper for calling merge_windowed_event with the correct event column names."""
     disp_event = display if display else event_cols[0]
@@ -163,7 +164,8 @@ def _merge_event(
         event_base_val_dtype=event_dtype,
         sort=sort,
         merge_strategy=config.events[disp_event].merge_strategy,
-        impute_val=impute_val,
+        impute_val_with_time=impute_pos,
+        impute_val_no_time=impute_neg,
     )
 
 

--- a/src/seismometer/data/loader/prediction.py
+++ b/src/seismometer/data/loader/prediction.py
@@ -103,6 +103,8 @@ def dictionary_types(config: ConfigProvider, dataframe: pd.DataFrame) -> pd.Data
     for col in dataframe.columns:
         if col in defined_types:
             try:
+                if "int" in defined_types[col].lower():
+                    dataframe[col] = dataframe[col].astype(float)
                 dataframe[col] = dataframe[col].astype(defined_types[col])
             except ValueError:
                 value_error_columns.append(col)

--- a/src/seismometer/data/loader/prediction.py
+++ b/src/seismometer/data/loader/prediction.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pyarrow.parquet as pq
 
 import seismometer.data.pandas_helpers as pdh
-from seismometer.configuration import ConfigProvider
+from seismometer.configuration import ConfigProvider, ConfigurationError
 
 logger = logging.getLogger("seismometer")
 
@@ -71,6 +71,55 @@ def _rename_targets(config: ConfigProvider, dataframe: pd.DataFrame) -> pd.DataF
 
 
 # post loaders
+def dictionary_types(config: ConfigProvider, dataframe: pd.DataFrame) -> pd.DataFrame:
+    """
+    Convert the loaded predictions dataframe to the expected types.
+
+    Prioritizes the types defined in the configuration dictionary, then falls back to assumed_types.
+
+
+    Parameters
+    ----------
+    config : ConfigProvider
+        The loaded configuration object.
+    dataframe : pd.DataFrame
+        The loaded predictions dataframe.
+
+    Returns
+    -------
+    pd.DataFrame
+        The predictions dataframe with adjusted types.
+
+    Raises
+    ------
+    ConfigurationError
+        If any columns cannot be converted to the expected types.
+    """
+
+    defined_types = _gather_defined_types(config)
+    unspecified_columns = []
+    value_error_columns = []
+
+    for col in dataframe.columns:
+        if col in defined_types:
+            try:
+                dataframe[col] = dataframe[col].astype(defined_types[col])
+            except ValueError:
+                value_error_columns.append(col)
+        else:
+            unspecified_columns.append(col)
+
+    if len(value_error_columns) > 0:
+        raise ConfigurationError(
+            f"Could not convert columns to expected types: {', '.join(value_error_columns)}. "
+            + "Update dictionary config or contact the model owner columns."
+        )
+
+    # Default to assumed types
+    dataframe[unspecified_columns] = assumed_types(config, dataframe[unspecified_columns])
+    return dataframe
+
+
 def assumed_types(config: ConfigProvider, dataframe: pd.DataFrame) -> pd.DataFrame:
     """
     Convert the loaded predictions dataframe to the expected types.
@@ -110,6 +159,15 @@ def assumed_types(config: ConfigProvider, dataframe: pd.DataFrame) -> pd.DataFra
 
 
 # other
+def _gather_defined_types(config: ConfigProvider) -> dict[str, str]:
+    """Gathers the defined types from the configuration dictionary."""
+    return {
+        defn.name: defn.dtype
+        for defn in config.prediction_defs.predictions
+        if getattr(defn, "dtype", None) is not None
+    }
+
+
 def _infer_datetime(dataframe, cols=None, override_categories=None):
     """Infers datetime columns based on column name and casts to pandas.datatime."""
     if cols is None:

--- a/src/seismometer/data/loader/prediction.py
+++ b/src/seismometer/data/loader/prediction.py
@@ -161,11 +161,7 @@ def assumed_types(config: ConfigProvider, dataframe: pd.DataFrame) -> pd.DataFra
 # other
 def _gather_defined_types(config: ConfigProvider) -> dict[str, str]:
     """Gathers the defined types from the configuration dictionary."""
-    return {
-        defn.name: defn.dtype
-        for defn in config.prediction_defs.predictions
-        if getattr(defn, "dtype", None) is not None
-    }
+    return {defn.name: defn.dtype for defn in config.prediction_defs.predictions if defn.dtype is not None}
 
 
 def _infer_datetime(dataframe, cols=None, override_categories=None):

--- a/src/seismometer/data/loader/prediction.py
+++ b/src/seismometer/data/loader/prediction.py
@@ -103,10 +103,8 @@ def dictionary_types(config: ConfigProvider, dataframe: pd.DataFrame) -> pd.Data
     for col in dataframe.columns:
         if col in defined_types:
             try:
-                if "int" in defined_types[col].lower():
-                    dataframe[col] = dataframe[col].astype(float)
-                dataframe[col] = dataframe[col].astype(defined_types[col])
-            except ValueError:
+                pdh.try_casting(dataframe, col, defined_types[col])
+            except ConfigurationError:
                 value_error_columns.append(col)
         else:
             unspecified_columns.append(col)

--- a/src/seismometer/data/pandas_helpers.py
+++ b/src/seismometer/data/pandas_helpers.py
@@ -179,6 +179,8 @@ def _one_event(
     # Cast event type
     if event_base_val_dtype is not None:
         try:
+            if "int" in event_base_val_dtype:  # "1.0" -> 1.0 then 1.0 -> 1
+                one_event[event_base_val_col] = one_event[event_base_val_col].astype(float)
             one_event[event_base_val_col] = one_event[event_base_val_col].astype(event_base_val_dtype)
         except (ValueError, TypeError) as exc:
             raise ConfigurationError(

--- a/src/seismometer/data/pandas_helpers.py
+++ b/src/seismometer/data/pandas_helpers.py
@@ -168,6 +168,7 @@ def _one_event(
     event_base_val_col: str,
     event_base_time_col: str,
     pks: list[str],
+    *,
     event_base_val_dtype: Optional[str] = None,
 ) -> pd.DataFrame:
     """Reduces the events dataframe to those rows associated with the event_label, preemptively renaming to the

--- a/src/seismometer/data/pandas_helpers.py
+++ b/src/seismometer/data/pandas_helpers.py
@@ -243,9 +243,8 @@ def post_process_event(
 
     # cast after imputation - supports nonnullable types
     try:
-        # TODO:
-        # if "int" in column_dtype.lower():  # "1.0" -> 1.0 then 1.0 -> 1
-        #    dataframe[label_col] = dataframe[label_col].astype(float)
+        if "int" in column_dtype.lower():  # "1.0" -> 1.0 then 1.0 -> 1
+            dataframe[label_col] = dataframe[label_col].astype(float)
         dataframe[label_col] = dataframe[label_col].astype(column_dtype)
     except (ValueError, TypeError) as exc:
         raise ConfigurationError(

--- a/src/seismometer/data/pandas_helpers.py
+++ b/src/seismometer/data/pandas_helpers.py
@@ -180,9 +180,9 @@ def _one_event(
     if event_base_val_dtype is not None:
         try:
             one_event[event_base_val_col] = one_event[event_base_val_col].astype(event_base_val_dtype)
-        except ValueError as exc:
+        except (ValueError, TypeError) as exc:
             raise ConfigurationError(
-                f"Cannot cast '{event_label}' values to {event_base_val_dtype}. "
+                f"Cannot cast '{event_label}' values to '{event_base_val_dtype}'. "
                 + "Update dictionary config or contact the model owner."
             ) from exc
 

--- a/src/seismometer/data/pandas_helpers.py
+++ b/src/seismometer/data/pandas_helpers.py
@@ -224,7 +224,9 @@ def post_process_event(
         return dataframe
 
     # use pandas for compatibility of imutations -- handle Nones
-    impute_val = pd.Series([impute_val_no_time or 0, impute_val_with_time or 1], dtype=(column_dtype or float)).values
+    impute_val = pd.Series(
+        [impute_val_no_time or 0, impute_val_with_time or 1], dtype=dataframe[label_col].dtype
+    ).values
 
     label_na_map = dataframe[label_col].isna()
     time_na_map = dataframe[time_col].isna()

--- a/tests/configuration/test_model.py
+++ b/tests/configuration/test_model.py
@@ -55,7 +55,7 @@ class TestEventDictionary:
         assert expected == actual
 
     @pytest.mark.parametrize("search_key,expected_key", [("evA", "filled"), ("evB", "given"), ("evC", "empty")])
-    def test_search_existing_returns_item(self, search_key, expected_key):
+    def test_search_returns_item(self, search_key, expected_key):
         inputs = [
             {"name": "evA", "display_name": "event_A"},
             {"name": "evB", "display_name": "event_B", "dtype": "int", "definition": "a definition"},
@@ -111,7 +111,7 @@ class TestPredictDictionary:
         assert expected == actual
 
     @pytest.mark.parametrize("search_key,expected_key", [("evA", "filled"), ("evB", "given"), ("evC", "empty")])
-    def test_search_existing_returns_item(self, search_key, expected_key):
+    def test_search_returns_item(self, search_key, expected_key):
         inputs = [
             {"name": "evA", "display_name": "event_A"},
             {"name": "evB", "display_name": "event_B", "dtype": "int", "definition": "a definition"},

--- a/tests/configuration/test_model.py
+++ b/tests/configuration/test_model.py
@@ -20,6 +20,118 @@ class TestDictionaryItem:
         assert dict_item.display_name == "a display"
 
 
+class TestEventDictionary:
+    def test_no_events_ok(self):
+        expected = {"events": []}
+
+        actual = undertest.EventDictionary().model_dump()
+
+        assert expected == actual
+
+    def test_minimal_item(self):
+        input = {"name": "evA", "display_name": "event_A"}
+
+        expected_event = input.copy()
+        expected_event.update({"dtype": None, "definition": None})
+        expected = {"events": [expected_event]}
+
+        event_dict = undertest.EventDictionary(events=[input])
+
+        actual = event_dict.model_dump()
+        assert expected == actual
+
+    def test_multiple_events(self):
+        input_min = {"name": "evA", "display_name": "event_A"}
+        input_full = {"name": "evB", "display_name": "event_B", "dtype": "int", "definition": "a definition"}
+        inputs = [input_min.copy(), input_full.copy()]
+
+        expected_event = input_min.copy()
+        expected_event.update({"dtype": None, "definition": None})
+        expected = {"events": [expected_event.copy(), input_full]}
+
+        event_dict = undertest.EventDictionary(events=inputs)
+
+        actual = event_dict.model_dump()
+        assert expected == actual
+
+    @pytest.mark.parametrize("search_key,expected_key", [("evA", "filled"), ("evB", "given"), ("evC", "empty")])
+    def test_search_existing_returns_item(self, search_key, expected_key):
+        inputs = [
+            {"name": "evA", "display_name": "event_A"},
+            {"name": "evB", "display_name": "event_B", "dtype": "int", "definition": "a definition"},
+        ]
+
+        filled = inputs[0].copy()
+        filled.update({"dtype": None, "definition": None})
+        expected_dict = {
+            "filled": undertest.DictionaryItem(**filled),
+            "given": undertest.DictionaryItem(**inputs[1]),
+            "empty": "MISSING",
+        }
+        expected = expected_dict[expected_key]
+
+        event_dict = undertest.EventDictionary(events=inputs)
+        actual = event_dict.get(search_key, "MISSING")
+
+        assert actual == expected
+
+
+class TestPredictDictionary:
+    def test_no_predictions_ok(self):
+        expected = {"predictions": []}
+
+        actual = undertest.PredictionDictionary().model_dump()
+
+        assert expected == actual
+
+    def test_minimal_item(self):
+        input = {"name": "prA", "display_name": "feature_A"}
+
+        expected_prediction = input.copy()
+        expected_prediction.update({"dtype": None, "definition": None})
+        expected = {"predictions": [expected_prediction]}
+
+        prediction_dict = undertest.PredictionDictionary(predictions=[input])
+
+        actual = prediction_dict.model_dump()
+        assert expected == actual
+
+    def test_multiple_predictions(self):
+        input_min = {"name": "prA", "display_name": "feature_A"}
+        input_full = {"name": "prB", "display_name": "feature_B", "dtype": "int", "definition": "a definition"}
+        inputs = [input_min.copy(), input_full.copy()]
+
+        expected_prediction = input_min.copy()
+        expected_prediction.update({"dtype": None, "definition": None})
+        expected = {"predictions": [expected_prediction.copy(), input_full]}
+
+        prediction_dict = undertest.PredictionDictionary(predictions=inputs)
+
+        actual = prediction_dict.model_dump()
+        assert expected == actual
+
+    @pytest.mark.parametrize("search_key,expected_key", [("evA", "filled"), ("evB", "given"), ("evC", "empty")])
+    def test_search_existing_returns_item(self, search_key, expected_key):
+        inputs = [
+            {"name": "evA", "display_name": "event_A"},
+            {"name": "evB", "display_name": "event_B", "dtype": "int", "definition": "a definition"},
+        ]
+
+        filled = inputs[0].copy()
+        filled.update({"dtype": None, "definition": None})
+        expected_dict = {
+            "filled": undertest.DictionaryItem(**filled),
+            "given": undertest.DictionaryItem(**inputs[1]),
+            "empty": "MISSING",
+        }
+        expected = expected_dict[expected_key]
+
+        event_dict = undertest.EventDictionary(events=inputs)
+        actual = event_dict.get(search_key, "MISSING")
+
+        assert actual == expected
+
+
 class TestEvent:
     expectation = {
         "source": ["source"],

--- a/tests/data/loaders/test_load_events.py
+++ b/tests/data/loaders/test_load_events.py
@@ -26,6 +26,8 @@ def fake_config(event_file):
             self.ev_time = "origTime"
             self.ev_value = "origValue"
 
+            self.event_defs = {}  # Fake EventDictionary.__item__
+
         # Aid setting a list of events (like that from config) but getting a dict like ConfigProvider returns
         @property
         def events(self):

--- a/tests/data/loaders/test_load_predictions.py
+++ b/tests/data/loaders/test_load_predictions.py
@@ -219,13 +219,13 @@ class TestDictionaryTypes:
         "defined_types,expected_dtypes",
         [
             pytest.param(
-                [{"name": "downcast", "dtype": "float16"}],
-                {"downcast": "float16", "assumedTime": "datetime64[ns]", "keep": "int64"},
+                [{"name": "downcast", "dtype": "float16"}, {"name": "hardint", "dtype": "int"}],
+                {"downcast": "float16", "assumedTime": "datetime64[ns]", "keep": "int64", "hardint": "int"},
                 id="basic types",
             )
         ],
     )
-    def test_defined_types_conversion(self, defined_types, expected_dtypes):
+    def test_defined_type_conversions_succeed(self, defined_types, expected_dtypes):
         config = Mock(spec=ConfigProvider)
         config.output_list = []
 
@@ -239,6 +239,8 @@ class TestDictionaryTypes:
                 "keep": [4, 5, 6],
             }
         )
+        # avoid pandas inferring
+        dataframe["hardint"] = pd.Series(["1.0", "0.0", "3.0"], dtype="string")
 
         actual_frame = undertest.dictionary_types(config, dataframe)
 

--- a/tests/data/loaders/test_loaders.py
+++ b/tests/data/loaders/test_loaders.py
@@ -29,7 +29,7 @@ class TestLoaderFactory:
             # Constructor exposed
             ("prediction_fn", undertest.prediction.parquet_loader),
             ("event_fn", undertest.event.parquet_loader),
-            ("post_predict_fn", undertest.prediction.assumed_types),
+            ("post_predict_fn", undertest.prediction.dictionary_types),
             ("post_event_fn", undertest.event.post_transform_fn),
             ("merge_fn", undertest.event.merge_onto_predictions),
             # Internal passthru_frame

--- a/tests/data/test_merge_window.py
+++ b/tests/data/test_merge_window.py
@@ -1076,7 +1076,7 @@ class TestMergeWindowedEvent:
             event_values=[1] * 5 + [None] * 5 + [1],
         )
 
-        expected_vals = ["0", "Test", "0", "1.0"]
+        expected_vals = ["0.0", "100.0", "0.0", "1.0"]
         expected_times = [
             pd.NaT,
             "2024-01-01 01:00:00",
@@ -1084,6 +1084,7 @@ class TestMergeWindowedEvent:
             "2024-12-01 00:00:00",
         ]
         expected = create_pred_event_frame(event_name, expected_vals, expected_times)
+        expected[f"{event_name}_Value"] = pd.Series(expected_vals, dtype="string")  # pandas infers numeric
 
         actual = undertest.merge_windowed_event(
             predictions,
@@ -1093,7 +1094,7 @@ class TestMergeWindowedEvent:
             ["Id"],
             merge_strategy="first",
             event_base_val_dtype="string",
-            impute_val_with_time="Test",
+            impute_val_with_time="100",  # must be compatible with other data even if string
         )
 
         # No CtxId_x

--- a/tests/data/test_merge_window.py
+++ b/tests/data/test_merge_window.py
@@ -1076,7 +1076,7 @@ class TestMergeWindowedEvent:
             event_values=[1] * 5 + [None] * 5 + [1],
         )
 
-        expected_vals = [0, "Test", 0, 1]
+        expected_vals = ["0", "Test", "0", "1.0"]
         expected_times = [
             pd.NaT,
             "2024-01-01 01:00:00",
@@ -1086,7 +1086,14 @@ class TestMergeWindowedEvent:
         expected = create_pred_event_frame(event_name, expected_vals, expected_times)
 
         actual = undertest.merge_windowed_event(
-            predictions, "PredictTime", events, event_name, ["Id"], merge_strategy="first", impute_val="Test"
+            predictions,
+            "PredictTime",
+            events,
+            event_name,
+            ["Id"],
+            merge_strategy="first",
+            event_base_val_dtype="string",
+            impute_val_with_time="Test",
         )
 
         # No CtxId_x

--- a/tests/data/test_pandas_helpers.py
+++ b/tests/data/test_pandas_helpers.py
@@ -87,7 +87,7 @@ def one_line_case():
         yield pytest.param(*row[:-1].values, id=row["description"])
 
 
-class TestInferLabel:
+class TestPostProcessEvent:
     @pytest.mark.parametrize("label_in,time_in,label_out", one_line_case())
     def test_infer_one_line(self, label_in, time_in, label_out):
         col_label = "Label"
@@ -95,7 +95,7 @@ class TestInferLabel:
         dataframe = pd.DataFrame({col_label: [label_in], col_time: pd.to_datetime([time_in])})
         expect = pd.DataFrame({col_label: [label_out], col_time: pd.to_datetime([time_in])})
 
-        actual = undertest.infer_label(dataframe, col_label, col_time)
+        actual = undertest.post_process_event(dataframe, col_label, col_time)
         # actual['Label'] = actual['Label'].astype(int) # handle inference where input frame could be all null series
 
         pdt.assert_frame_equal(actual, expect, check_dtype=False)
@@ -109,7 +109,7 @@ class TestInferLabel:
         dataframe = all_cases.iloc[:, :2].rename(columns={k: v for k, v in col_map.items() if k in all_cases.columns})
         expect = all_cases.iloc[:, 2:0:-1].rename(columns={k: v for k, v in col_map.items() if k in all_cases.columns})
 
-        actual = undertest.infer_label(dataframe, col_label, col_time)
+        actual = undertest.post_process_event(dataframe, col_label, col_time)
 
         pdt.assert_frame_equal(actual, expect, check_dtype=False)
 


### PR DESCRIPTION
# Overview
Previously the data dictionary objects allowed for specification of data types but they were ignored, instead assuming that the parquet files had the appropriate data types.
Now the data loader casts them

## Description of changes
- The events value is cast to the dictionary specification prior to merge; this is the most needed because Value holds all data so is "multitype".  The caveat is that multiple sources might have conflicting dtypes, in this case the first is used and a warning logged.
- The predictions data is cast as an updated post_predict_fn by the loader.  The dictionary spec is prioritized, but the assumed_type (outputs and datetimes) are still called if the feature is not listed.
- Other minor changes were done to make sure that dictionary.yml is still an optional file. And so that dictionaries can be accessed by the source 'name'; ex config.event_defs['MyEvent'].


- [x] TODO: Once the PR on data goes through to change target type, update download location

## Testing script
[_Make use of the example notebook dictionary yml misalignment_]
- [ ] Run the example notebook and verify it works (pre-update this is actually the case of a missing dictionary.yml)
- [ ] Update cell 1 to save it to data_dictionary.yml; this should fail in part because pd.merge_asof() will change the dtype from bool to object and then sklearn chokes.
- [x] Update data_dictionary.yml (~last line) to be of dtype int.
- [x] Delete the dtype and rerun to verify no casting occurs
- [x] Delete the entire events block of the dictionary and verify it works with found file and no config
- [ ] 
## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
