### PR TITLE
Add a dictionary creator

### DIFF
--- a/changelog/93.feature.rst
+++ b/changelog/93.feature.rst
@@ -1,0 +1,1 @@
+Add a configuration helper that can generate a dictionary file for events or predictions.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -29,3 +29,12 @@ Configuration DataModel
    EventTableMap
    OtherInfo
    PredictionDictionary
+
+Configuration Helper
+~~~~~~~~~~~~~~~~~~~~
+.. currentmodule:: seismometer.configuration.config_helpers
+
+.. autosummary::
+   :toctree: api/
+
+   generate_dictionary_from_parquet

--- a/src/seismometer/configuration/config_helpers.py
+++ b/src/seismometer/configuration/config_helpers.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+import pandas as pd
+
+from seismometer.core.io import write_yaml
+
+from .model import DictionaryItem, EventDictionary, PredictionDictionary
+
+
+def generate_dictionary_from_parquet(
+    inpath: Path | str, outpath: Path | str, section: str = "predictions", *, column: str = "Type"
+) -> None:
+    """
+    Generate a data dictionary YAML file from a parquet file.
+
+    Parameters
+    ----------
+    inpath : Path | str
+        The path to the input Parquet file.
+    outpath : Path | str
+        The path to the output YAML file.
+    section : str, optional
+        The section name to be used in the YAML file, by default "predictions".
+    column : str, optional
+        The column name of data relevant to defining the dictionary; currently used
+        for events section, by default "Type".
+    """
+    df = pd.read_parquet(inpath)
+
+    datadict = None
+    match section:
+        case "predictions":
+            datadict = _generate_prediction_dictionary(df)
+        case "events":
+            datadict = _generate_event_dictionary(df, column)
+        case _:
+            raise ValueError(f"Section {section} not recognized; only supports predictions and events")
+
+    if not datadict:
+        raise ValueError("No items generated; check the input file")
+
+    write_yaml(datadict.model_dump(), outpath)
+
+
+def _generate_prediction_dictionary(df: pd.DataFrame) -> PredictionDictionary:
+    """Generates dictionary based on columns in the DataFrame"""
+    items = [
+        DictionaryItem(name=c, dtype=str(df[c].dtype), definition=f"Placeholder description for {c}")
+        for c in df.columns
+    ]
+    return PredictionDictionary(predictions=items)
+
+
+def _generate_event_dictionary(df, column="Type") -> EventDictionary:
+    """Generates entry for each unique value in the specified column"""
+    items = [
+        DictionaryItem(name=c, dtype="string", definition=f"Placeholder description for {c}")
+        for c in df[column].unique()
+    ]
+    return EventDictionary(events=items)

--- a/src/seismometer/core/io.py
+++ b/src/seismometer/core/io.py
@@ -59,6 +59,7 @@ def slugify(value: str) -> str:
 # region io-accessor functions
 read_ipynb = partial(nbformat.read, as_version=nbformat.current_nbformat)
 dump_json_pretty = partial(json.dump, indent=4)
+dump_yaml = yaml.dump
 
 
 def _print_to_file(content, fo):
@@ -234,6 +235,20 @@ def _load(loader: Callable["fileobject", Any], filepath: Path, resource_dir: Pat
 
 # endregion
 # region write functions
+def write_yaml(content: dict, filepath: Path, *, overwrite: bool = False) -> None:
+    """
+    Writes a dictionary to a YAML file.
+
+    Parameters
+    ----------
+    content : dict
+        The dictionary to write.
+    filepath : Path
+        The location to write.
+    overwrite : bool, optional
+        Write the file even if one exists, by default False.
+    """
+    _write(dump_yaml, content, filepath, overwrite)
 
 
 def write_markdown(content: str, filepath: Path, *, overwrite: bool = False) -> None:
@@ -303,7 +318,6 @@ def _write(writer: Callable[[Any, "fileobject"], None], content: Any, file: Path
         If True, writes the file even if one exists.
 
     """
-
     file = Path(file)
     if file.is_file() and not overwrite:
         raise FileExistsError(f"File already exists: {file.resolve()}; Specify overwrite to write anyway.")

--- a/src/seismometer/core/io.py
+++ b/src/seismometer/core/io.py
@@ -12,8 +12,23 @@ import nbformat
 import yaml
 
 Pathlike = str | Path
-
 logger = logging.getLogger("seismometer")
+
+# region io-accessor functions
+read_ipynb = partial(nbformat.read, as_version=nbformat.current_nbformat)
+dump_json_pretty = partial(json.dump, indent=4)
+dump_yaml = yaml.dump
+
+
+def _read_text(fo):
+    return fo.readlines()
+
+
+def _print_to_file(content, fo):
+    print(content, file=fo)
+
+
+# endregion
 
 
 def slugify(value: str) -> str:
@@ -54,23 +69,6 @@ def slugify(value: str) -> str:
         hash_str = hashlib.md5(value.encode()).hexdigest()
         value = value[:50] + hash_str
     return value
-
-
-# region io-accessor functions
-read_ipynb = partial(nbformat.read, as_version=nbformat.current_nbformat)
-dump_json_pretty = partial(json.dump, indent=4)
-dump_yaml = yaml.dump
-
-
-def _print_to_file(content, fo):
-    print(content, file=fo)
-
-
-def _read_text(fo):
-    return fo.readlines()
-
-
-# endregion
 
 
 def resolve_filename(

--- a/tests/configuration/test_helpers.py
+++ b/tests/configuration/test_helpers.py
@@ -80,3 +80,11 @@ class TestGenerateDict:
             undertest.generate_dictionary_from_parquet("TESTIN", "out.yml", section=section_type)
 
         assert section_type in str(err.value)
+
+
+# This is intentionally outside the class to NOT use the shared pd patch
+@pytest.mark.parametrize("section_type", ["events", "predictions"])
+@patch.object(undertest.pd, "read_parquet", return_value=pd.DataFrame())
+def test_generate_dict_no_data_raises_error(mock_read, section_type, tmp_as_current):
+    with pytest.raises(ValueError, match="No data loaded"):
+        undertest.generate_dictionary_from_parquet("TESTIN", "out.yml", section=section_type)

--- a/tests/configuration/test_helpers.py
+++ b/tests/configuration/test_helpers.py
@@ -1,0 +1,82 @@
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+import seismometer.configuration.config_helpers as undertest
+from seismometer.core.io import load_yaml
+
+
+def frame_case():
+    df = pd.DataFrame({"Type": ["A", "B", "C", "B"], "IntCol": [1, 2, 3, 4]})
+    df.Type = df.Type.astype("category")
+    df.IntCol = df.IntCol.astype("int32")
+
+    return df
+
+
+@pytest.mark.usefixtures("tmp_as_current")
+@patch.object(pd, "read_parquet", return_value=frame_case())
+class TestGenerateDict:
+    def test_generate_events(self, mock_read):
+        outfile = "out.yml"
+        expected = {
+            "events": [
+                {
+                    "definition": "Placeholder description for A",
+                    "display_name": "A",
+                    "dtype": "string",
+                    "name": "A",
+                },
+                {
+                    "definition": "Placeholder description for B",
+                    "display_name": "B",
+                    "dtype": "string",
+                    "name": "B",
+                },
+                {
+                    "definition": "Placeholder description for C",
+                    "display_name": "C",
+                    "dtype": "string",
+                    "name": "C",
+                },
+            ]
+        }
+
+        undertest.generate_dictionary_from_parquet("TESTIN", outfile, section="events")
+        actual = load_yaml(outfile)
+
+        mock_read.assert_called_once_with("TESTIN")
+        assert actual == expected
+
+    def test_generate_predictions(self, mock_read):
+        outfile = "out.yml"
+        expected = {
+            "predictions": [
+                {
+                    "definition": "Placeholder description for Type",
+                    "display_name": "Type",
+                    "dtype": "category",
+                    "name": "Type",
+                },
+                {
+                    "definition": "Placeholder description for IntCol",
+                    "display_name": "IntCol",
+                    "dtype": "int32",
+                    "name": "IntCol",
+                },
+            ]
+        }
+
+        undertest.generate_dictionary_from_parquet("TESTIN", outfile, section="predictions")
+        actual = load_yaml(outfile)
+
+        mock_read.assert_called_once_with("TESTIN")
+        assert actual == expected
+
+    def test_generate_dict_invalid_section(self, mock_read):
+        section_type = "invalid"
+        with pytest.raises(ValueError, match="not recognized") as err:
+            undertest.generate_dictionary_from_parquet("TESTIN", "out.yml", section=section_type)
+
+        assert section_type in str(err.value)

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -168,6 +168,27 @@ class TestJsonWriters:
         assert actual == self.content
 
 
+class TestYamlWriters:
+    file = Path("test.yml")
+    content = {"topkey": {"key1": "value1"}}
+
+    def test_write_yaml(self, tmp_as_current):
+        undertest.write_yaml(self.content, self.file)
+        assert self.file.read_text().strip() == "topkey:\n  key1: value1"
+
+    def test_write_yaml_fails_if_file_exists(self, tmp_as_current):
+        self.file.touch()
+
+        with pytest.raises(FileExistsError):
+            undertest.write_yaml(self.content, self.file)
+
+    def test_overwrite_yaml_if_specified(self, tmp_as_current):
+        self.file.touch()
+
+        undertest.write_yaml(self.content, self.file, overwrite=True)
+        assert self.file.read_text().strip() == "topkey:\n  key1: value1"
+
+
 def test_write_new_file_in_nonexistent_directory(tmp_as_current):
     file = Path("nonexistent_directory") / "new_file.txt"
     undertest._write(lambda content, fo: fo.write(content), "test content", file, overwrite=False)


### PR DESCRIPTION
# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->
Closes #93

## Description of changes
(Re)Added generate_data_dict_from_parquet as a configuration helper.  
Enhanced to support events as well as predictions
Added tests

## Author Checklist
- [x] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [x] Tests added for new code and issue being fixed.
- [x] Added type annotations and full numpy-style docstrings for new methods.
- [x] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
