### PR TITLE
Fairness Fixes: Minor UX Changes

### DIFF
--- a/changelog/109.bugfix.rst
+++ b/changelog/109.bugfix.rst
@@ -1,4 +1,5 @@
-Fixes a few minor ux issues
+Fixes a few minor ux issues.
+
 - Disable dropdowns with only one valid option.
 - Fix the Sensitivity/Specificity/PPV plot to move the label to the lower right.
 - Fix the Legend in the new Fairness Audit table to improve readability.

--- a/changelog/109.bugfix.rst
+++ b/changelog/109.bugfix.rst
@@ -1,0 +1,5 @@
+Fixes a few minor ux issues
+- Disable dropdowns with only one valid option.
+- Fix the Sensistivity/Specificity/PPV plot to move the label to the lower right.
+- Fix the Legend in the new Fairness Audit table to improve readability.
+- Add right border to the count column.

--- a/changelog/109.bugfix.rst
+++ b/changelog/109.bugfix.rst
@@ -1,5 +1,5 @@
 Fixes a few minor ux issues
 - Disable dropdowns with only one valid option.
-- Fix the Sensistivity/Specificity/PPV plot to move the label to the lower right.
+- Fix the Sensitivity/Specificity/PPV plot to move the label to the lower right.
 - Fix the Legend in the new Fairness Audit table to improve readability.
 - Add right border to the count column.

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -227,7 +227,7 @@ on a predetermined set while remaining aware of the others.
 This audit should be used by experts with a deep understanding of the
 model and the context in which the predictions are used. Even when a
 metric is flagged as a deviation in the fairness audit, the context 
-might that explains or even predict the difference. Like many
+might explain or even predict the difference. Like many
 concepts, a single parity concept can have several different names;
 notably, parity of true positive rate is equal opportunity, parity of
 false positive rate is predictive equality, and parity of predictive

--- a/src/seismometer/controls/explore.py
+++ b/src/seismometer/controls/explore.py
@@ -113,9 +113,14 @@ class ModelOptionsWidget(VBox, ValueWidget):
             value=target_names[0],
             description="Target Column",
             style=WIDE_LABEL_STYLE,
+            disabled=len(target_names) == 1,
         )
         self.score_list = Dropdown(
-            options=score_names, value=score_names[0], description="Score Column", style=WIDE_LABEL_STYLE
+            options=score_names,
+            value=score_names[0],
+            description="Score Column",
+            style=WIDE_LABEL_STYLE,
+            disabled=len(score_names) == 1,
         )
 
         self.target_list.observe(self._on_value_change, "value")
@@ -155,8 +160,8 @@ class ModelOptionsWidget(VBox, ValueWidget):
     @disabled.setter
     def disabled(self, disabled: bool):
         self._disabled = disabled
-        self.target_list.disabled = disabled
-        self.score_list.disabled = disabled
+        self.target_list.disabled = len(self.target_list.options) == 1 or disabled
+        self.score_list.disabled = len(self.score_list.options) == 1 or disabled
         if self.threshold_list:
             self.threshold_list.disabled = disabled
         if self.per_context_checkbox:
@@ -253,7 +258,7 @@ class ModelScoreComparisonOptionsWidget(VBox, ValueWidget):
     @disabled.setter
     def disabled(self, disabled: bool):
         self._disabled = disabled
-        self.target_list.disabled = disabled
+        self.target_list.disabled = len(self.target_list.options) == 1 or disabled
         self.score_list.disabled = disabled
         if self.per_context_checkbox:
             self.per_context_checkbox.disabled = disabled
@@ -413,7 +418,7 @@ class ModelTargetComparisonOptionsWidget(VBox, ValueWidget):
     def disabled(self, disabled: bool):
         self._disabled = disabled
         self.target_list.disabled = disabled
-        self.score_list.disabled = disabled
+        self.score_list.disabled = len(self.score_list.options) == 1 or disabled
         if self.per_context_checkbox:
             self.per_context_checkbox.disabled = disabled
 

--- a/src/seismometer/controls/selection.py
+++ b/src/seismometer/controls/selection.py
@@ -246,7 +246,9 @@ class DisjointSelectionListsWidget(ValueWidget, VBox):
             selection_value = values[dropdown_value]
             value = (dropdown_value, selection_value)
 
-        self.dropdown = Dropdown(options=[key for key in values], value=value[0], layout=DROPDOWN_LAYOUT)
+        self.dropdown = Dropdown(
+            options=[key for key in values], value=value[0], layout=DROPDOWN_LAYOUT, disabled=len(values) == 1
+        )
 
         self.dropdown.observe(self._on_selection_change, "value")
         self.selection_widgets = {}
@@ -269,7 +271,7 @@ class DisjointSelectionListsWidget(ValueWidget, VBox):
     @disabled.setter
     def disabled(self, disabled: bool):
         self._disabled = disabled
-        self.dropdown.disabled = disabled
+        self.dropdown.disabled = len(self.dropdown.options) == 1 or disabled
         for widget in self.selection_widgets.values():
             widget.disabled = disabled
 

--- a/src/seismometer/html/template.py
+++ b/src/seismometer/html/template.py
@@ -125,7 +125,7 @@ def render_censored_data_message(message: str) -> HTML:
     HTML
         The templated HTML.
     """
-    return render_title_message("Data is censored.", message)
+    return render_title_message("Censored", message)
 
 
 def render_title_with_image(title: str, image: SVG) -> HTML:

--- a/src/seismometer/plot/mpl/_lines.py
+++ b/src/seismometer/plot/mpl/_lines.py
@@ -168,7 +168,7 @@ def performance_metrics_plot(axis, sensitivity, specificity, ppv, thresholds) ->
     axis.plot(thresholds, sensitivity, label="Sensitivity")
     axis.plot(thresholds, specificity, label="Specificity")
     axis.plot(thresholds, ppv, label="PPV")
-    axis.legend(loc="lower center")
+    axis.legend(loc="lower right")
 
     axis.set_xlim([0, 1.01])
     axis.set_xlabel("Threshold")

--- a/src/seismometer/report/fairness.py
+++ b/src/seismometer/report/fairness.py
@@ -55,7 +55,7 @@ class FairnessIcons(Enum):
 <td style="text-align: left;">{cls.CRITICAL_HIGH.value} More than {2*limit:.2%} greater than the default cohort.</td>
 </tr>
 <tr style="background: none;">
-<td style="text-align: left;">{cls.UNKNOWN.value} Fewer than {censor_threshold} observations, data was censored.</td>
+<td style="text-align: left;">{cls.UNKNOWN.value} Censored, fewer than {censor_threshold} observations.</td>
 </tr>
 </details>"""
         )
@@ -249,14 +249,18 @@ def fairness_table(
         GT(table_data)
         .tab_stub(groupname_col=COHORT, rowname_col=CLASS)
         .tab_style(
+            style=style.text(align="center"),
+            locations=loc.column_header(),
+        )
+        .tab_style(
             style=style.borders(sides=["right"], weight="1px", color="#D3D3D3"),
             locations=loc.body(columns=[COUNT] + metric_list),
         )
-        .cols_align(align="left")
-        .cols_align(align="right", columns=[COUNT])
         .tab_source_note(source_note=legend)
         .opt_horizontal_padding(scale=3)
         .tab_options(row_group_font_weight="bold")
+        .cols_align(align="left")
+        .cols_align(align="right", columns=[COUNT])
     ).as_raw_html()
     return HTML(table_html, layout=Layout(max_height="800px"))
 

--- a/src/seismometer/report/fairness.py
+++ b/src/seismometer/report/fairness.py
@@ -17,6 +17,10 @@ from seismometer.data.performance import BinaryClassifierMetricGenerator, Metric
 
 logger = logging.getLogger("seismometer")
 
+COUNT = "Count"
+COHORT = "Cohort"
+CLASS = "Class"
+
 
 # region Fairness Icons
 class FairnessIcons(Enum):
@@ -36,22 +40,22 @@ class FairnessIcons(Enum):
     def get_fairness_legend(cls, limit: float = 0.25, *, open: bool = True, censor_threshold: int = 10) -> str:
         return html(
             f"""
-<details {'open' if open else ''}><summary>Legend</summary>
+<details {'open' if open else ''}><summary><span style="font-size: 100%; font-weight: bold;">Legend</span></summary>
 <table>
 <tr style="background: none;">
-<td style="text-align: left;">{cls.DEFAULT.value} the default cohort for the category</td>
-<td style="text-align: left;">{cls.GOOD.value} within {limit:.2%} of the default cohort</td>
+<td style="text-align: left;">{cls.DEFAULT.value} The default cohort for the category.</td>
+<td style="text-align: left;">{cls.GOOD.value} Within {limit:.2%} of the default cohort.</td>
 </tr>
 <tr style="background: none;">
-<td style="text-align: left;">{cls.WARNING_LOW.value} within {2*limit:.2%} lower than the default cohort</td>
-<td style="text-align: left;">{cls.WARNING_HIGH.value} within {2*limit:.2%} greater than the default cohort</td>
+<td style="text-align: left;">{cls.WARNING_LOW.value} Within {2*limit:.2%} lower than the default cohort.</td>
+<td style="text-align: left;">{cls.WARNING_HIGH.value} Within {2*limit:.2%} greater than the default cohort.</td>
 </tr>
 <tr style="background: none;">
-<td style="text-align: left;">{cls.CRITICAL_LOW.value} more than {2*limit:.2%} lower than the default cohort</td>
-<td style="text-align: left;">{cls.CRITICAL_HIGH.value} more than {2*limit:.2%} greater than the default cohort</td>
+<td style="text-align: left;">{cls.CRITICAL_LOW.value} More than {2*limit:.2%} lower than the default cohort.</td>
+<td style="text-align: left;">{cls.CRITICAL_HIGH.value} More than {2*limit:.2%} greater than the default cohort.</td>
 </tr>
 <tr style="background: none;">
-<td style="text-align: left;">{cls.UNKNOWN.value} fewer than {censor_threshold} observations, data was censored</td>
+<td style="text-align: left;">{cls.UNKNOWN.value} Fewer than {censor_threshold} observations, data was censored.</td>
 </tr>
 </details>"""
         )
@@ -127,7 +131,7 @@ def sort_fairness_table(dataframe: pd.DataFrame, cohort_groups: tuple[str]):
             case _:
                 return key
 
-    return dataframe.sort_values(by=["Cohort", "Count"], key=fairness_sort_key)
+    return dataframe.sort_values(by=[COHORT, COUNT], key=fairness_sort_key)
 
 
 def fairness_table(
@@ -196,20 +200,20 @@ def fairness_table(
             cohort_filter = FilterRule.eq(cohort_column, cohort_class)
             cohort_dataframe = cohort_filter.filter(dataframe)
 
-            index_value = {"Count": len(cohort_dataframe)}
+            index_value = {COUNT: len(cohort_dataframe)}
             metrics = metric_fn(cohort_dataframe, metric_list, **kwargs)
             index_value.update(metrics)
 
             cohort_values.append(index_value)
         cohort_data = pd.DataFrame.from_records(
-            cohort_values, index=pd.MultiIndex.from_tuples(cohort_indices, names=["Cohort", "Class"])
+            cohort_values, index=pd.MultiIndex.from_tuples(cohort_indices, names=[COHORT, CLASS])
         )
-        cohort_ratios = cohort_data.div(cohort_data.loc[cohort_data["Count"].idxmax()], axis=1)
+        cohort_ratios = cohort_data.div(cohort_data.loc[cohort_data[COUNT].idxmax()], axis=1)
 
-        cohort_icons = cohort_ratios.drop("Count", axis=1).applymap(
+        cohort_icons = cohort_ratios.drop(COUNT, axis=1).applymap(
             lambda ratio: FairnessIcons.get_fairness_icon(ratio, fairness_ratio)
         )
-        cohort_icons["Count"] = cohort_data["Count"]
+        cohort_icons[COUNT] = cohort_data[COUNT]
 
         fairness_groups.append(cohort_ratios)
         icon_groups.append(cohort_icons)
@@ -220,8 +224,8 @@ def fairness_table(
     fairness_icons = pd.concat(icon_groups)
 
     for cohort_column, cohort_class in metric_data.index:
-        if metric_data.loc[(cohort_column, cohort_class), "Count"] < censor_threshold:
-            fairness_icons.loc[(cohort_column, cohort_class), "Count"] = FairnessIcons.UNKNOWN.value
+        if metric_data.loc[(cohort_column, cohort_class), COUNT] < censor_threshold:
+            fairness_icons.loc[(cohort_column, cohort_class), COUNT] = FairnessIcons.UNKNOWN.value
             for metric in metric_list:
                 fairness_icons.loc[(cohort_column, cohort_class), metric] = FairnessIcons.UNKNOWN
                 metric_data.loc[(cohort_column, cohort_class), metric] = np.nan
@@ -238,23 +242,23 @@ def fairness_table(
 
     legend = FairnessIcons.get_fairness_legend(fairness_ratio, censor_threshold=censor_threshold)
 
-    table_data = fairness_icons.reset_index()[["Cohort", "Class", "Count"] + metric_list]
+    table_data = fairness_icons.reset_index()[[COHORT, CLASS, COUNT] + metric_list]
     table_data = sort_fairness_table(table_data, list(cohort_dict.keys()))
 
     table_html = (
         GT(table_data)
-        .tab_stub(groupname_col="Cohort", rowname_col="Class")
+        .tab_stub(groupname_col=COHORT, rowname_col=CLASS)
         .tab_style(
             style=style.borders(sides=["right"], weight="1px", color="#D3D3D3"),
-            locations=loc.body(columns=metric_list),
+            locations=loc.body(columns=[COUNT] + metric_list),
         )
         .cols_align(align="left")
-        .cols_align(align="right", columns=["Count"])
+        .cols_align(align="right", columns=[COUNT])
         .tab_source_note(source_note=legend)
         .opt_horizontal_padding(scale=3)
         .tab_options(row_group_font_weight="bold")
     ).as_raw_html()
-    return HTML(table_html)
+    return HTML(table_html, layout=Layout(max_height="800px"))
 
 
 # region Fairness Table Wrapper

--- a/src/seismometer/report/fairness.py
+++ b/src/seismometer/report/fairness.py
@@ -33,7 +33,7 @@ class FairnessIcons(Enum):
     CRITICAL_LOW = "🔻"
 
     @classmethod
-    def get_fairness_legend(cls, limit: float = 0.25, *, open: bool = False, censor_threshold: int = 10) -> str:
+    def get_fairness_legend(cls, limit: float = 0.25, *, open: bool = True, censor_threshold: int = 10) -> str:
         return html(
             f"""
 <details {'open' if open else ''}><summary>Legend</summary>

--- a/tests/controls/test_explore.py
+++ b/tests/controls/test_explore.py
@@ -253,6 +253,17 @@ class TestModelOptionsWidget:
         assert widget.per_context_checkbox.disabled
         assert widget.disabled
 
+    def test_disabled_by_list_size(self):
+        widget = undertest.ModelOptionsWidget(
+            target_names=["T1"], score_names=["S1"], thresholds={"T1": 0.1, "T2": 0.2}, per_context=False
+        )
+        widget.disabled = False
+        assert widget.target_list.disabled
+        assert widget.score_list.disabled
+        assert not widget.threshold_list.disabled
+        assert not widget.per_context_checkbox.disabled
+        assert not widget.disabled
+
 
 class TestModelOptionsAndCohortsWidget:
     def test_init(self):
@@ -387,6 +398,12 @@ class TestModelScoreComparisonOptionsWidget:
         assert widget.score_list.disabled
         assert widget.disabled
 
+    def test_disabled_by_list_size(self):
+        widget = undertest.ModelScoreComparisonOptionsWidget(target_names=["T1"], score_names=["S1", "S2"])
+        widget.disabled = False
+        assert widget.target_list.disabled  # only one target
+        assert not widget.disabled
+
     def test_init_per_context(self):
         widget = undertest.ModelScoreComparisonOptionsWidget(
             target_names=["T1", "T2"], score_names=["S1", "S2", "S3", "S4"], per_context=True
@@ -455,6 +472,12 @@ class TestModelTargetComparisonOptionsWidget:
         assert widget.score_list.disabled
         assert widget.per_context_checkbox.disabled
         assert widget.disabled
+
+    def test_disabled_by_list_size(self):
+        widget = undertest.ModelTargetComparisonOptionsWidget(target_names=["T1", "T2"], score_names=["S1"])
+        widget.disabled = False
+        assert widget.score_list.disabled  # only one score
+        assert not widget.disabled
 
 
 class TestModelScoreComparisonAndCohortsWidget:

--- a/tests/controls/test_selection.py
+++ b/tests/controls/test_selection.py
@@ -164,16 +164,16 @@ class TestDisjointSelectionListsWidget:
 
     def test_display_text(self):
         widget = undertest.DisjointSelectionListsWidget(
-            options={"a": ["a", "b", "c"], "b": ["a", "c"]},
-            value=("a", ["a", "b"]),
+            options={"a": ["a1", "a2", "a3"], "b": ["b1", "b2"]},
+            value=("a", ["a1", "a3"]),
             title="title",
         )
-        assert widget.get_selection_text() == "a: a, b"
+        assert widget.get_selection_text() == "a: a1, a3"
 
     def test_disabled(self):
         widget = undertest.DisjointSelectionListsWidget(
-            options={"a": ["a", "b", "c"], "b": ["a", "c"]},
-            value=("a", ["a", "b"]),
+            options={"a": ["a1", "a2", "a3"], "b": ["b1", "b2"]},
+            value=("a", ["a1", "a3"]),
             title="title",
         )
         assert not widget.disabled
@@ -187,6 +187,22 @@ class TestDisjointSelectionListsWidget:
         assert not widget.dropdown.disabled
         assert not widget.selection_widgets["a"].disabled
         assert not widget.selection_widgets["b"].disabled
+
+    def test_disable_dropdown_only_one_group(self):
+        widget = undertest.DisjointSelectionListsWidget(
+            options={"a": ["a1", "a2", "a3"]},
+            value=("a", ["a1", "a2"]),
+            title="title",
+        )
+        assert not widget.disabled
+        widget.disabled = True
+        assert widget.disabled
+        assert widget.dropdown.disabled
+        assert widget.selection_widgets["a"].disabled
+        widget.disabled = False
+        assert not widget.disabled
+        assert widget.dropdown.disabled
+        assert not widget.selection_widgets["a"].disabled
 
 
 class TestMultiselectDropdownWidget:

--- a/tests/html/test_templates.py
+++ b/tests/html/test_templates.py
@@ -86,12 +86,12 @@ class Test_Templates:
 
     def test_censored_plot_template(self):
         html_source = undertest.render_censored_plot_message(3).data
-        assert "censored" in html_source
+        assert "Censored" in html_source
         assert "There are 3 or fewer observations." in html_source
 
     def test_censored_data_template(self):
         html_source = undertest.render_censored_data_message(Exception("Somthing Bad Happened")).data
-        assert "censored" in html_source
+        assert "Censored" in html_source
         assert "Somthing Bad Happened" in html_source
 
     def test_title_image_template(self):


### PR DESCRIPTION
# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->
Fixes a few minor ux issues
 
## Description of changes
- Disable dropdowns with only one valid option.
 
![image](https://github.com/user-attachments/assets/f6bc92d9-2a0a-4585-b8d9-6a1163841672)


- Fix the Sensitivity/Specificity/PPV plot to move the label to the lower right.

![image](https://github.com/user-attachments/assets/9be47a07-99be-4179-a1be-6d977a37ac36)

- Fix the Legend in the new Fairness Audit table to improve readability.

![image](https://github.com/user-attachments/assets/9cebda37-5b08-48f8-8276-9925423688bd)

- Add right border to the count column.

![image](https://github.com/user-attachments/assets/eea489aa-4188-420a-a209-94acf6ba28b1)


## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
