### PR TITLE
Initialize more attributes

### DIFF
--- a/changelog/120.bugfix.rst
+++ b/changelog/120.bugfix.rst
@@ -1,1 +1,1 @@
-Initialize Seismogram values to prevent AttributeErrors like availablet-cohort_group
+Initialize Seismogram values to prevent AttributeErrors like available_cohort_group

--- a/changelog/120.bugfix.rst
+++ b/changelog/120.bugfix.rst
@@ -1,0 +1,1 @@
+Initialize Seismogram values to prevent AttributeErrors like availablet-cohort_group

--- a/src/seismometer/seismogram.py
+++ b/src/seismometer/seismogram.py
@@ -64,6 +64,8 @@ class Seismogram(object, metaclass=Singleton):
         if config is None or dataloader is None:
             raise ValueError("Seismogram has not been initialized; requires Config and dataloader on initial call.")
 
+        self._initialize_attrs()
+
         self.config = config
         self.dataloader = dataloader
 
@@ -71,6 +73,23 @@ class Seismogram(object, metaclass=Singleton):
         self.cohort_cols: list[str] = []
 
         self.copy_config_metadata()
+
+    def _initialize_attrs(self):
+        """
+        Initialize attributes
+        """
+        # _df_counts
+        self._start_time = None
+        self._end_time = None
+        self._prediction_count = 0
+        self._entity_count = 0
+        self._event_types_count = 0
+        self._cohort_attribute_count = 0
+        self._feature_counts = 0
+
+        # load data
+        self.available_cohort_groups = dict()
+        self.selected_cohort = (None, None)  # column, values
 
     def load_data(
         self, *, predictions: Optional[pd.DataFrame] = None, events: Optional[pd.DataFrame] = None, reset: bool = False

--- a/tests/test_seismogram.py
+++ b/tests/test_seismogram.py
@@ -234,3 +234,25 @@ class TestSeismogramCreateCohorts:
         assert "Some cohorts" in caplog.records[0].message
         assert "rareVals" in caplog.records[0].message
         assert sg.cohort_cols == ["cohort1", "cohort2", "rareVals"]
+
+
+class TestSeismogramAttrs:
+    @pytest.mark.parametrize(
+        "attr_name",
+        [
+            "start_time",
+            "end_time",
+            "prediction_count",
+            "entity_count",
+            "event_types_count",
+            "cohort_attribute_count",
+            "feature_count",
+            "target_event",
+            "dataframe",
+        ],
+    )
+    def test_attribute_exists(self, fake_seismo, attr_name):
+        sg = Seismogram()
+
+        # Ensure attribute is available
+        assert hasattr(sg, attr_name)


### PR DESCRIPTION
# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->
Closes #120 

## Description of changes
Add a new function called early in Seismogram constructor to initialize several attributes in case they are not set later.  
The reported issue is specifically available_cohort_groups.  

These all seem most likely to arise when the dataset (or cohort selection) is so small that there wouldn't be valuable insights anyway, but should still be handled.


## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
