### PR TITLE
Scaling roc

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
     "dockerComposeFile": "docker-compose.yml",
     "service": "seismometer-dev",
     "workspaceFolder": "/home/seismo/workspace",
+    "features": {
+        "ghcr.io/devcontainers/features/git:1": {}
+    },
      // Use 'settings' to set *default* container specific settings.json values on container create.
     // You can edit these settings after create using File > Preferences > Settings > Remote.
     "customizations": {

--- a/changelog/124.bugfix.rst
+++ b/changelog/124.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a scaling issue causing annotations to be misplaced on the ROC plot of the evaluation 2x3

--- a/src/seismometer/api/plots.py
+++ b/src/seismometer/api/plots.py
@@ -566,8 +566,10 @@ def _model_evaluation(
         return template.render_title_message(
             "Evaluation Error", f"Model Evaluation requires exactly two classes but found {lcount}"
         )
+
+    # stats and ci handle percentile/percentage independently - evaluation wants 0-100 for displays
     stats = calculate_bin_stats(data[target], data[score_col])
-    ci_data = calculate_eval_ci(stats, data[target], data[score_col], conf=0.95)
+    ci_data = calculate_eval_ci(stats, data[target], data[score_col], conf=0.95, force_percentages=True)
     title = f"Overall Performance for {target_event} (Per {'Encounter' if per_context_id else 'Observation'})"
     svg = plot.evaluation(
         stats,

--- a/src/seismometer/data/performance.py
+++ b/src/seismometer/data/performance.py
@@ -390,7 +390,9 @@ def calculate_nnt(arr: np.ndarray, rho: Optional[Number | None] = None) -> np.nd
 
 
 @export
-def calculate_eval_ci(stats: pd.DataFrame, truth: pd.Series, output: pd.Series, conf: Number = 0.95) -> dict:
+def calculate_eval_ci(
+    stats: pd.DataFrame, truth: pd.Series, output: pd.Series, conf: Number = 0.95, force_percentages=False
+) -> dict:
     """
     Calculate confidence intervals for ROC, PR, and other performance metrics from a stats frame.
 
@@ -404,6 +406,8 @@ def calculate_eval_ci(stats: pd.DataFrame, truth: pd.Series, output: pd.Series, 
         The series of model output associated with the stats frame.
     conf : Number, optional
         The confidence level for calculation, by default 0.95.
+    force_percentages : bool, optional
+        Flag to indicate that outputs should be converted to percentages (0-100), by default False.
 
     Returns
     -------
@@ -416,6 +420,9 @@ def calculate_eval_ci(stats: pd.DataFrame, truth: pd.Series, output: pd.Series, 
     conf = confidence_dict(conf)
     if truth is None or output is None:
         return conf, None, None, None
+
+    if force_percentages:
+        output = as_percentages(output)
 
     roc_conf = ROCConfidenceParam(conf)
     aucpr_conf = PRConfidenceParam(conf)

--- a/src/seismometer/plot/mpl/_lines.py
+++ b/src/seismometer/plot/mpl/_lines.py
@@ -251,14 +251,13 @@ def add_radial_score_thresholds(
     y : np.ndarray
         Array of y-values.
     labels : list[str]
-        Array of thresholds to display.
-    colorIx : int, optional
-        Index of line being annotated in order to match color, by default 0.
-    n_scores : int, optional
-        Integer number of scores to display, if length of arrays is greater, will automatically
-        select 10 values to shows based on an assumed range of labels being 0-1 (default: 10).
+        Array of labels to display.
+    thresholds : list[Number]
+        List of threshold points to label.
     Q : int, optional
         The quadrant 1-4 to assume for offsets, by default 1.
+    colorIx : int, optional
+        Index of line being annotated in order to match color, by default 0.
     """
     if labels is None:
         return

--- a/src/seismometer/plot/mpl/_lines.py
+++ b/src/seismometer/plot/mpl/_lines.py
@@ -225,7 +225,9 @@ def get_last_line_color(axis):
     return lines[-1].get_color()
 
 
-def add_radial_score_thresholds(
+# endregion
+# region Private Helpers
+def _add_radial_score_thresholds(
     axis: plt.Axes,
     x: np.ndarray,
     y: np.ndarray,
@@ -238,9 +240,6 @@ def add_radial_score_thresholds(
     Add threshold annotations on points as if it were a quarter-circle.
 
     Expected use is for ROC curves with either scores or n_scores roughly spaced along the curve.
-
-    If the three arrays (x, y, and labels) have more values then n_scores, labels will only be added
-    for a reduced list of len(n_scores) == 10 by default.
 
     Parameters
     ----------
@@ -294,7 +293,7 @@ def add_radial_score_thresholds(
     for i, ix in enumerate(val_ix):
         axis.annotate(
             f"{thresholds[i]:.0f}",
-            radial_annotations(x[ix], y[ix], Q=Q),
+            _radial_annotations(x[ix], y[ix], Q=Q),
             color=colors[i],
         )
 
@@ -312,7 +311,7 @@ def _find_thresholds(labels: list[float], thresholds: list[float]) -> list[int]:
     return val_ix
 
 
-def add_radial_score_labels(
+def _add_radial_score_labels(
     axis: plt.Axes,
     x: np.ndarray,
     y: np.ndarray,
@@ -352,7 +351,7 @@ def add_radial_score_labels(
 
     """
     if highlight is not None:
-        return add_radial_score_thresholds(axis, x, y, labels, thresholds=highlight, Q=Q)
+        return _add_radial_score_thresholds(axis, x, y, labels, thresholds=highlight, Q=Q)
 
     # For safety convert to handle indexing lists
     x = np.array(x)
@@ -378,14 +377,12 @@ def add_radial_score_labels(
     for ix in labelIx:
         axis.annotate(
             f"{labels[ix]:.1f}",
-            radial_annotations(x[ix], y[ix], Q),
+            _radial_annotations(x[ix], y[ix], Q),
             color=text_colors[colorIx],
         )
 
 
-# endregion
-# region Private Helpers
-def radial_annotations(x, y, Q=1) -> tuple[float, float]:
+def _radial_annotations(x, y, Q=1) -> tuple[float, float]:
     """
     Takes a single point and offsets it, returning the modified values.
 

--- a/src/seismometer/plot/mpl/binary_classifier.py
+++ b/src/seismometer/plot/mpl/binary_classifier.py
@@ -61,10 +61,15 @@ def evaluation(
         prevalence = prevalence / stats.loc[0, ["TP", "FP", "TN", "FN"]].sum()
 
     roc_data = ci_data["roc"]
+    roc_thresholds = roc_data["Threshold"]
+    # Normalize roc_data like stats; ignore infs inserted at beginning
+    if not (roc_thresholds[2:] > 2).any():
+        roc_thresholds = roc_thresholds * 100
+
     singleROC(
         roc_data["TPR"],
         roc_data["FPR"],
-        roc_data["Threshold"],
+        roc_thresholds,
         conf_region=roc_data["region"],
         conf_interval=roc_data["interval"],
         axis=ax1,

--- a/src/seismometer/plot/mpl/binary_classifier.py
+++ b/src/seismometer/plot/mpl/binary_classifier.py
@@ -151,7 +151,7 @@ def singleROC(
     lines.roc_plot(axis, fpr, tpr, label=modelLabel)
 
     if annotate:
-        lines.add_radial_score_labels(axis, fpr, tpr, thresholds, highlight=highlight)
+        lines._add_radial_score_labels(axis, fpr, tpr, thresholds, highlight=highlight)
     return axis.get_figure()
 
 
@@ -193,7 +193,7 @@ def recall_condition(
     lines.recall_condition_plot(axis, ppcr, recall, prevalence, show_reference)
 
     if annotate:
-        lines.add_radial_score_labels(axis, ppcr, recall, thresholds, highlight=highlight)
+        lines._add_radial_score_labels(axis, ppcr, recall, thresholds, highlight=highlight)
     return axis.get_figure()
 
 
@@ -321,7 +321,7 @@ def ppv_vs_sensitivity(
     lines.ppv_sensitivity_curve(axis, sensitivity, ppv, label=aucpr)
 
     if highlight is not None:
-        lines.add_radial_score_thresholds(axis, sensitivity, ppv, thresholds, thresholds=highlight, Q=4)
+        lines._add_radial_score_thresholds(axis, sensitivity, ppv, thresholds, thresholds=highlight, Q=4)
     return axis.get_figure()
 
 

--- a/src/seismometer/plot/mpl/binary_classifier.py
+++ b/src/seismometer/plot/mpl/binary_classifier.py
@@ -61,15 +61,10 @@ def evaluation(
         prevalence = prevalence / stats.loc[0, ["TP", "FP", "TN", "FN"]].sum()
 
     roc_data = ci_data["roc"]
-    roc_thresholds = roc_data["Threshold"]
-    # Normalize roc_data like stats; ignore infs inserted at beginning
-    if not (roc_thresholds[2:] > 2).any():
-        roc_thresholds = roc_thresholds * 100
-
     singleROC(
         roc_data["TPR"],
         roc_data["FPR"],
-        roc_thresholds,
+        roc_data["Threshold"],
         conf_region=roc_data["region"],
         conf_interval=roc_data["interval"],
         axis=ax1,


### PR DESCRIPTION
# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->
Closes #124 

## Description of changes
Changed model evaluation code (binary classifiers) to scale the threshold info for ROC annotations

![image](https://github.com/user-attachments/assets/9af8b423-4a1e-4fbd-986f-ff79d860fc91)

### Testing
Verify the docs include a notebook with corrected annotations like that above - verify all 6 plots  
Alter the score data to be from 0-100,  sm.Seismogram().dataframe['Risk30DayReadmission']*100 rerun and verify it is still ok.


## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
