### PR TITLE
Support reading parquet files from non-Pandas sources

### DIFF
--- a/src/seismometer/data/loader/prediction.py
+++ b/src/seismometer/data/loader/prediction.py
@@ -42,7 +42,7 @@ def parquet_loader(config: ConfigProvider) -> pd.DataFrame:
         actual_columns = desired_columns & present_columns
         _log_column_mismatch(actual_columns, desired_columns, present_columns)
 
-        dataframe = pd.read_parquet(config.prediction_path, columns=actual_columns)
+        dataframe = pd.read_parquet(config.prediction_path, columns=list(actual_columns))
 
     dataframe = _rename_targets(config, dataframe)
 

--- a/src/seismometer/data/loader/prediction.py
+++ b/src/seismometer/data/loader/prediction.py
@@ -38,10 +38,8 @@ def parquet_loader(config: ConfigProvider) -> pd.DataFrame:
 
         if config.target in present_columns:
             desired_columns.add(config.target)
-
         actual_columns = desired_columns & present_columns
         _log_column_mismatch(actual_columns, desired_columns, present_columns)
-
         dataframe = pd.read_parquet(config.prediction_path, columns=list(actual_columns))
 
     dataframe = _rename_targets(config, dataframe)


### PR DESCRIPTION
# Overview
Creating a parquet file with e.g. Polars will write a file without pandas-related metadata.  Pandas is able to read files without this metadata, but a possible bug in the API requires that calls to `pandas.read_parquet` for these kinds of files be made such that the `columns` parameter must *strictly* be a list of strings and not a set. If Pandas metadata is present in the parquet file, Pandas will accept a set of columns and normalize it to a list internally. If the metadata is not present, calling the function with a set will yield a stacktrace like the following:

```
/home/seismo/workspace/tests/data/loaders/test_load_predictions.py:124: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/seismo/workspace/src/seismometer/data/loader/prediction.py:43: in parquet_loader
    dataframe = pd.read_parquet(config.prediction_path, columns=actual_columns)
/home/seismo/.local/lib/python3.11/site-packages/pandas/io/parquet.py:667: in read_parquet
    return impl.read(
/home/seismo/.local/lib/python3.11/site-packages/pandas/io/parquet.py:274: in read
    pa_table = self.api.parquet.read_table(
/home/seismo/.local/lib/python3.11/site-packages/pyarrow/parquet/core.py:1843: in read_table
    return dataset.read(columns=columns, use_threads=use_threads,
/home/seismo/.local/lib/python3.11/site-packages/pyarrow/parquet/core.py:1485: in read
    table = self._dataset.to_table(
pyarrow/_dataset.pyx:553: in pyarrow._dataset.Dataset.to_table
    ???
pyarrow/_dataset.pyx:399: in pyarrow._dataset.Dataset.scanner
    ???
pyarrow/_dataset.pyx:3594: in pyarrow._dataset.Scanner.from_dataset
    ???
pyarrow/_dataset.pyx:3512: in pyarrow._dataset.Scanner._make_scan_options
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   ValueError: Expected a list or a dict for 'columns', got <class 'set'> instead.
```

## Description of changes
To prevent this from happening, just explicitly cast the columns variable in `parquet_loader` to a list of strings after doing the set intersection. This shouldn't be a significant source of overhead because as far as I can tell this is only done once per file load.

## Author Checklist
- [x] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [x] Tests added for new code and issue being fixed.
- [x] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
