### PR TITLE
fix the issue with how per context data is filtered for each score, t…

### DIFF
--- a/src/seismometer/data/binary_performance.py
+++ b/src/seismometer/data/binary_performance.py
@@ -180,8 +180,8 @@ def generate_analytics_data(
     for first, second in product:
         current_row = {top_level: first, second_level: second}
         (score, target) = (first, second) if top_level == "Score" else (second, first)
-        if per_context:
-            data = pdh.event_score(
+        per_context_data = (
+            pdh.event_score(
                 data,
                 sg.entity_keys,
                 score=score,
@@ -189,9 +189,12 @@ def generate_analytics_data(
                 ref_event=target,
                 aggregation_method=sg.event_aggregation_method(target),
             )
+            if per_context
+            else data
+        )
         current_row.update(
             calculate_stats(
-                data[[target, score]],
+                per_context_data[[target, score]],
                 target_col=target,
                 score_col=score,
                 metric=metric,


### PR DESCRIPTION
# Overview
In `generate_analytics_data` with `per_context=True`, data is filtered consecutively and this could cause combining scores to not work as intended for more than one `(score, target)` pair.

## Description of changes
Update `generate_analytics_data` to do:
```python
for first, second in product:
        current_row = {top_level: first, second_level: second}
        (score, target) = (first, second) if top_level == "Score" else (second, first)
        per_context_data = (
            pdh.event_score(
                data,
                sg.entity_keys,
                score=score,
                ref_time=sg.predict_time,
                ref_event=target,
                aggregation_method=sg.event_aggregation_method(target),
            )
            if per_context
            else data
        )
        current_row.update(
            calculate_stats(
                per_context_data[[target, score]],
                target_col=target,
                score_col=score,
                metric=metric,
                metric_values=metric_values,
                metrics_to_display=metrics_to_display,
                decimals=decimals,
            )
        )
```

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
