### PR TITLE
Improve accuracy of AUC computation in analytics table

### DIFF
--- a/changelog/153.bugfix.rst
+++ b/changelog/153.bugfix.rst
@@ -1,0 +1,1 @@
+Improve threshold precision handling and formatting in analytics tables and slider widgets for more accurate AUC computation.

--- a/src/seismometer/controls/thresholds.py
+++ b/src/seismometer/controls/thresholds.py
@@ -42,11 +42,11 @@ class ProbabilitySliderListWidget(ValueWidget, VBox):
         readout_fmt = f".{decimals}f"
         values = tuple(0 for _ in names) if not value else tuple(value)  # set initial values
         values = tuple(min(1.0, max(0, val)) for val in values)  # clamp values to [0, 1]
-        self.value = {k: v for k, v in zip(self.names, values)}
+        self.value = {k: round(v, self.decimals) for k, v in zip(self.names, values)}
         self.sliders = {}
         for name, val in self.value.items():
             sub_slider = FloatSlider(
-                value=val,
+                value=round(val, self.decimals),
                 min=0,
                 max=1.0,
                 step=step_size,

--- a/src/seismometer/controls/thresholds.py
+++ b/src/seismometer/controls/thresholds.py
@@ -15,24 +15,31 @@ logger = logging.getLogger("seismometer")
 
 class ProbabilitySliderListWidget(ValueWidget, VBox):
     """
-    Vertical list of sliders, bounded between 0 and 1 with a step of 0.01.
+    Vertical list of sliders, bounded between 0 and 1 with a dynamic step size based on specified decimal precision.
     """
 
     value = traitlets.Dict(help="The names and values for the slider list")
 
-    def __init__(self, names: Iterable[str], value: Optional[Iterable[int]] = None):
-        """A vertical list of sliders, bounded between 0 and 1 with a step of 0.01.
+    def __init__(self, names: Iterable[str], value: Optional[Iterable[float]] = None, decimals: int = 2):
+        """
+        Vertical list of sliders, bounded between 0 and 1 with a dynamic step size
+        based on specified decimal precision.
 
         Parameters
         ----------
         names : Iterable[str]
             Slider names
-        value : Optional[Iterable[int]], optional
+        value : Optional[Iterable[float]], optional
             Slider start values, by default None, starts all sliders at zero.
+        decimals : int, optional
+            Number of decimal places (determines slider step size, e.g., 2 → 0.01), by default 2.
         """
         self.names = tuple(names)  # cast to static tuple
         if value and len(value) != len(names):
             raise ValueError(f"Value length {len(value)} does not match names length {len(names)}")
+        self.decimals = decimals
+        step_size = 1 / 10**decimals
+        readout_fmt = f".{decimals}f"
         values = tuple(0 for _ in names) if not value else tuple(value)  # set initial values
         values = tuple(min(1.0, max(0, val)) for val in values)  # clamp values to [0, 1]
         self.value = {k: v for k, v in zip(self.names, values)}
@@ -42,14 +49,14 @@ class ProbabilitySliderListWidget(ValueWidget, VBox):
                 value=val,
                 min=0,
                 max=1.0,
-                step=0.01,
+                step=step_size,
                 description=name,
                 tooltip=name,
                 disabled=False,
                 continuous_update=False,
                 orientation="horizontal",
                 readout=True,
-                readout_format=".2f",
+                readout_format=readout_fmt,
                 style=WIDE_LABEL_STYLE,
             )
             self.sliders[name] = sub_slider
@@ -77,7 +84,8 @@ class ProbabilitySliderListWidget(ValueWidget, VBox):
             return
         if change:
             if (slider := change["owner"]) in self.sliders.values():
-                self.value[slider.description] = slider.value
+                rounded_val = round(slider.value, self.decimals)
+                self.value[slider.description] = rounded_val
 
     def _on_value_change(self, change=None):
         """Bubble up changes to sliders"""
@@ -85,33 +93,44 @@ class ProbabilitySliderListWidget(ValueWidget, VBox):
         if change:
             if val := change["new"]:
                 for key, value in val.items():
-                    self.sliders[key].value = value
+                    rounded_val = round(value, self.decimals)
+                    self.sliders[key].value = rounded_val
         self.value_update_in_progress = False
 
 
 class MonotonicProbabilitySliderListWidget(ProbabilitySliderListWidget):
     """
-    Vertical list of sliders, bounded between 0 and 1 with a step of 0.01.
+    A vertical list of probability sliders, each bounded between 0 and 1, with dynamic step size
+    based on the specified decimal precision.
+
     Monotonicity is maintained between the sliders so they are always ascending or descending in value.
+
+    Supports up to 6 sliders.
     """
 
-    def __init__(self, names: Iterable[str], value: Optional[Iterable[int]] = None, ascending: bool = True):
-        """A vertical list of sliders, bounded between 0 and 1 with a step of 0.01.
+    def __init__(
+        self, names: Iterable[str], value: Optional[Iterable[float]] = None, ascending: bool = True, decimals: int = 2
+    ):
+        """
+        A vertical list of sliders, bounded between 0 and 1 with dynamic step size
+        based on the specified decimal precision.
 
         Parameters
         ----------
         names : Iterable[str]
             Slider names
-        value : Optional[Iterable[int]], optional
+        value : Optional[Iterable[float]], optional
             Slider start values, by default None, starts all sliders at zero.
         ascending : bool, optional = True
             Forces sliders to be ascending, else decreasing.
             If initial values are not sorted, raise an ValueError.
+        decimals : int, optional
+            Number of decimal places for slider precision (affects step size and rounding), by default 2.
         """
         if len(names) > 6:
             raise ValueError("MonotonicProbabilitySliderListWidget only supports up to 6 sliders")
 
-        super().__init__(names, value)
+        super().__init__(names, value, decimals)
 
         thresholds = list(self.value.values())
         op = operator.le if ascending else operator.ge
@@ -158,4 +177,5 @@ class MonotonicProbabilitySliderListWidget(ProbabilitySliderListWidget):
                 new_tuple = [slider.value for slider in sliders[:slider_index]] + [
                     min(new, slider.value) for slider in sliders[slider_index:]
                 ]
+        new_tuple = [round(min(1.0, max(0.0, v)), self.decimals) for v in new_tuple]
         self.value = {k: v for k, v in zip(self.sliders.keys(), new_tuple)}

--- a/src/seismometer/data/binary_performance.py
+++ b/src/seismometer/data/binary_performance.py
@@ -82,6 +82,7 @@ def calculate_stats(
         target_col=target_col,
         score_col=score_col,
         metrics=metrics_to_display,
+        threshold_precision=decimals - 2,
     )
     stats = stats.reset_index()
 

--- a/src/seismometer/data/performance.py
+++ b/src/seismometer/data/performance.py
@@ -164,7 +164,7 @@ class BinaryClassifierMetricGenerator(MetricGenerator):
         stats = stats.loc[score_threshold_integer]
         return stats.to_dict()
 
-    def calculate_binary_stats(self, dataframe, target_col, score_col, metrics):
+    def calculate_binary_stats(self, dataframe, target_col, score_col, metrics, threshold_precision=0):
         """
         Calculates binary stats for all thresholds.
 
@@ -178,10 +178,20 @@ class BinaryClassifierMetricGenerator(MetricGenerator):
             The column in the dataframe that contains the predicted scores.
         metrics: list[str], optional
             List of metrics to filter down to.
+        threshold_precision : int, optional
+            Number of decimal places to use when generating thresholds as percentages.
+            - E.g., `threshold_precision=0` yields thresholds like 0, 1, ..., 100 (coarse).
+            - `threshold_precision=2` yields 0.00, 0.01, ..., 100.00 (fine-grained).
+            - Higher values improve AUC approximation but increase computation cost.
+            By default 0.
         """
         y_true = dataframe[target_col]
         y_pred = dataframe[score_col]
-        stats = calculate_bin_stats(y_true, y_pred, rho=self.rho).round(5).set_index(THRESHOLD)
+        stats = (
+            calculate_bin_stats(y_true, y_pred, rho=self.rho, threshold_precision=threshold_precision)
+            .round(5)
+            .set_index(THRESHOLD)
+        )
         for name, percent in zip(COUNTS, PERCENTS):
             stats[percent] = stats[name] * 100.0 / len(dataframe)
 
@@ -242,6 +252,7 @@ def calculate_bin_stats(
     keep_score_values: bool = False,
     not_point_thresholds: bool = False,
     rho: float = None,
+    threshold_precision: int = 0,
 ) -> pd.DataFrame:
     """
     Calculate summary statistics from y_true and y_pred (y_proba[:,1] for binary classification) arrays.
@@ -259,6 +270,12 @@ def calculate_bin_stats(
         If True, does not use point thresholds, by default False; uses 0-100.
     rho : float, optional
         The relative risk reduction for NNT calculation, by default DEFAULT_RHO.
+    threshold_precision : int, optional
+        Number of decimal places to use when generating thresholds as percentages.
+        - E.g., `threshold_precision=0` yields thresholds like 0, 1, ..., 100 (coarse).
+        - `threshold_precision=2` yields 0.00, 0.01, ..., 100.00 (fine-grained).
+        - Higher values improve AUC approximation but increase computation cost.
+        By default 0.
 
     Returns
     -------
@@ -297,7 +314,7 @@ def calculate_bin_stats(
     # Reduce thresholds to table 0-100
     # This can reintroduce redundant thresholds, particularly in sparse regions
     if not not_point_thresholds:
-        threshold_ix, thresholds = _point_thresholds(thresholds)
+        threshold_ix, thresholds = _point_thresholds(thresholds, threshold_precision)
         tps = tps[threshold_ix]
         fps = fps[threshold_ix]
 
@@ -434,14 +451,14 @@ def calculate_eval_ci(
         output = as_percentages(output)
 
     roc_conf = ROCConfidenceParam(conf)
-    aucpr_conf = PRConfidenceParam(conf)
+    auprc_conf = PRConfidenceParam(conf)
     with np.errstate(invalid="ignore", divide="ignore"):
         # roc
         thresholds, tpr, fpr, auc_region = roc_conf.region(roc_conf, truth, output)
         auc_interval = roc_conf.interval(roc_conf, truth, output)
         # pr
-        aucpr_interval = aucpr_conf.interval(
-            aucpr_conf,
+        auprc_interval = auprc_conf.interval(
+            auprc_conf,
             auc(stats.Sensitivity, stats.PPV),
             stats[["TP", "FP", "TN", "FN"]].iloc[0].sum(),
         )
@@ -454,7 +471,7 @@ def calculate_eval_ci(
             "region": auc_region,
             "interval": auc_interval,
         },
-        "pr": {"interval": aucpr_interval},
+        "pr": {"interval": auprc_interval},
         "conf": conf,
     }
     return ci_data
@@ -483,13 +500,19 @@ def _bin_class_curve(
     return fps, tps, y_pred[threshold_idxs]
 
 
-def _point_thresholds(orig_thresholds: np.ndarray) -> np.ndarray:
+def _point_thresholds(orig_thresholds: np.ndarray, threshold_precision: int = 0) -> np.ndarray:
     """
-    Convert thresholds to percent increments (0.01) between 0 to 1.
+    Convert float thresholds into evenly spaced percent thresholds between 0 and 100,
+    with granularity based on the specified number of decimal places.
     """
     if orig_thresholds.max() < 1:
         logger.warning("Passed thresholds do not extend to maximum of 1.")
-    thresholds = np.arange(0, 101)[::-1]
+
+    # Compute number of divisions per unit based on precision
+    step_size = 10**threshold_precision
+    num_steps = 100 * step_size
+
+    thresholds = (np.arange(0, num_steps + 1)[::-1]) / step_size  # Convert to percent scale
     ixs = np.digitize(thresholds, orig_thresholds, right=True) - 1
     ixs = np.where(ixs < 0, 0, ixs)  # Clip to 0
     ixs[-1] = -1  # Keep the last threshold

--- a/src/seismometer/plot/mpl/binary_classifier.py
+++ b/src/seismometer/plot/mpl/binary_classifier.py
@@ -303,22 +303,22 @@ def ppv_vs_sensitivity(
     thresholds : pd.Series
         The thresholds of the model, used for annotations.
     conf_interval : Optional['ValueWithCI'], optional
-        The confidence interval for the AUCPR, by default None.
+        The confidence interval for the AUPRC, by default None.
     highlight : Optional[list[Number]], optional
         A list of thresholds to highlight on the plot, by default None.
     axis : Optional[plt.Axes], optional
         The matplotlib axis to draw, by default None; creates a new figure.
     """
-    aucpr = f"AUCPR = {metrics.auc(sensitivity, ppv):0.2f}"
+    auprc = f"AUPRC = {metrics.auc(sensitivity, ppv):0.2f}"
 
     if conf_interval is not None:
-        aucpr = "AUCPR = %0.2f (%0.2f, %0.2f)" % (
+        auprc = "AUPRC = %0.2f (%0.2f, %0.2f)" % (
             metrics.auc(sensitivity, ppv),
             conf_interval.lower,
             conf_interval.upper,
         )
 
-    lines.ppv_sensitivity_curve(axis, sensitivity, ppv, label=aucpr)
+    lines.ppv_sensitivity_curve(axis, sensitivity, ppv, label=auprc)
 
     if highlight is not None:
         lines._add_radial_score_thresholds(axis, sensitivity, ppv, thresholds, thresholds=highlight, Q=4)

--- a/tests/controls/test_thresholds.py
+++ b/tests/controls/test_thresholds.py
@@ -48,6 +48,12 @@ class TestPercentSliderWidget:
         assert widget.sliders["a"].disabled
         assert widget.sliders["b"].disabled
 
+    def test_values_are_rounded_to_decimal_precision(self):
+        widget = undertest.ProbabilitySliderListWidget(("a", "b"), (0.1234, 0.5678), decimals=3)
+        assert widget.sliders["a"].value == round(0.1234, 3)
+        assert widget.sliders["b"].value == round(0.5678, 3)
+        assert widget.value == {"a": 0.123, "b": 0.568}
+
 
 class TestMonotonicPercentSliderWidget:
     def test_init(self):
@@ -120,3 +126,15 @@ class TestMonotonicPercentSliderWidget:
         with pytest.raises(ValueError):
             threshold_names = [str(x) for x in range(7)]
             undertest.MonotonicProbabilitySliderListWidget(threshold_names)
+
+    def test_slider_values_are_rounded_to_decimal_precision(self):
+        widget = undertest.MonotonicProbabilitySliderListWidget(("a", "b"), (0.1234, 0.5678), decimals=2)
+        assert widget.sliders["a"].value == round(0.1234, 2)
+        assert widget.sliders["b"].value == round(0.5678, 2)
+        assert widget.value == {"a": 0.12, "b": 0.57}
+
+    def test_slider_interaction_respects_decimals(self):
+        widget = undertest.MonotonicProbabilitySliderListWidget(("a", "b"), (0.1, 0.2), decimals=2)
+        widget.sliders["a"].value = 0.23456
+        assert widget.sliders["a"].value == round(0.23456, 2)
+        assert widget.value["a"] == 0.23

--- a/tests/data/test_binary_performance.py
+++ b/tests/data/test_binary_performance.py
@@ -292,7 +292,9 @@ class TestGenerateAnalyticsData:
             val_high = result_high[col].iloc[0]
 
             # Values differ (better precision affects threshold resolution)
-            assert val_low != val_high, "Differing precision expected, test seed was chosen to verify these two values are not equal"
+            assert (
+                val_low != val_high
+            ), "Differing precision expected, test seed was chosen to verify these two values are not equal"
 
             # But still close enough (numerically stable)
             assert np.isclose(val_low, val_high, atol=atol)

--- a/tests/data/test_binary_performance.py
+++ b/tests/data/test_binary_performance.py
@@ -292,7 +292,7 @@ class TestGenerateAnalyticsData:
             val_high = result_high[col].iloc[0]
 
             # Values differ (better precision affects threshold resolution)
-            assert val_low != val_high
+            assert val_low != val_high, "Differing precision expected, test seed was chosen to verify these two values are not equal"
 
             # But still close enough (numerically stable)
             assert np.isclose(val_low, val_high, atol=atol)


### PR DESCRIPTION
# Overview
We generally use an approximation with 101 threshold points to estimate AUC. In plots like `ExploreModelEvaluation`, where values are displayed with only two decimal places, this approximation is sufficient. However, in `ExploreAnalyticsTable`, which displays values to three decimal places, the difference between using 101 points and a full-resolution calculation becomes more noticeable.
Closes #141 

## Description of changes
To improve the accuracy of AUC in `ExploreAnalyticsTable` while maintaining performance, we now use 1001 threshold points instead of 101. This offers a better balance between precision and efficiency, especially given the increased decimal display precision.

## Author Checklist
- [x] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
