### PR TITLE
Add parens for warning message details

### DIFF
--- a/changelog/158.bugfix.rst
+++ b/changelog/158.bugfix.rst
@@ -1,0 +1,1 @@
+Fix warning message for missing times to display count instead of bool.

--- a/src/seismometer/data/pandas_helpers.py
+++ b/src/seismometer/data/pandas_helpers.py
@@ -299,7 +299,7 @@ def _merge_event_counts(
         if len(right_filtered := right[right[r_ref].notna()]) == 0:
             logger.warning(f"No times found for {event_name}! Unable to merge any counts.")
             return left
-        if diff := len(right) - len(right_filtered) > 0:
+        if (diff := len(right) - len(right_filtered)) > 0:
             logger.warning(f"Found {diff} rows with missing times for {event_name}. These rows will be ignored.")
             right = right_filtered
 


### PR DESCRIPTION
## Description of changes
Tiny change to add parens around walrus so we have reference to the count and not just the boolean

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
