### PR TITLE
update perf tests to make adding metrics easier

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "features": {
         "ghcr.io/devcontainers/features/git:1": {}
     },
-     // Use 'settings' to set *default* container specific settings.json values on container create.
+    // Use 'settings' to set *default* container specific settings.json values on container create.
     // You can edit these settings after create using File > Preferences > Settings > Remote.
     "customizations": {
         "vscode": {
@@ -17,7 +17,7 @@
                 "autoDocstring.docstringFormat": "numpy",
                 "python.venvPath": "/env/python"
             },
-          // Add the IDs of extensions you want installed when the container is created in the array below.
+            // Add the IDs of extensions you want installed when the container is created in the array below.
             "extensions": [
                 // language servers
                 "ms-python.python",
@@ -37,7 +37,7 @@
                 "johnpapa.vscode-peacock",
                 //copilot
                 "github.copilot",
-                "github.copilot-chat"
+                "GitHub.copilot-chat"
             ]
         }
     },


### PR DESCRIPTION
# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->
Makes it easier to add new metrics by turning the unit tests into individual metric checks rather than checking entire dataframes against each other. 

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
