### PR TITLE
add other_value and top_k transform for cohorts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ example-notebooks/binary-classifier/data/*
 example-notebooks/binary-classifier/outputs/*
 
 .seismometer_cache/
+tests/.DS_Store

--- a/src/seismometer/configuration/model.py
+++ b/src/seismometer/configuration/model.py
@@ -191,6 +191,12 @@ class Cohort(BaseModel):
     splits: Optional[list[Any]] = []
     """ An optional list of 'inner edges' used to create a set of cohorts from a continuous attribute."""
 
+    top_k: Optional[int] = None
+    """If set, only the top K most common values will be selected; all others grouped into 'Other'."""
+
+    other_value: Union[float, str] = None
+    """Value to use for the 'Other' category when grouping less common values. Only used if top_k is set."""
+
     @field_validator("display_name")
     def default_display_name(cls, display_name: str, values: dict) -> str:
         """Ensures that display_name exists, setting it to the source name if not provided."""

--- a/src/seismometer/seismogram.py
+++ b/src/seismometer/seismogram.py
@@ -10,7 +10,7 @@ from seismometer.configuration import AggregationStrategies, ConfigProvider, Mer
 from seismometer.configuration.model import Metric
 from seismometer.core.patterns import Singleton
 from seismometer.data import pandas_helpers as pdh
-from seismometer.data import resolve_cohorts
+from seismometer.data import resolve_cohorts, resolve_top_k_cohorts
 from seismometer.data.loader import SeismogramLoader
 from seismometer.report.alerting import AlertConfigProvider
 
@@ -380,6 +380,16 @@ class Seismogram(object, metaclass=Singleton):
                     new_col = resolve_cohorts(self.dataframe[cohort.source], cohort.splits)
                 except IndexError as exc:
                     logger.warning(f"Failed to resolve cohort {disp_attr}: {exc}")
+                    continue
+            elif cohort.top_k is not None:
+                try:
+                    new_col = resolve_top_k_cohorts(
+                        self.dataframe[cohort.source],
+                        top_k=cohort.top_k,
+                        other_value=cohort.other_value,
+                    )
+                except ValueError as exc:
+                    logger.warning(f"Failed to resolve top K cohorts {disp_attr}: {exc}")
                     continue
             else:
                 new_col = pd.Series(pd.Categorical(self.dataframe[cohort.source]))

--- a/tests/configuration/test_model.py
+++ b/tests/configuration/test_model.py
@@ -219,27 +219,51 @@ class TestEvent:
 
 class TestCohort:
     def test_default_values(self):
-        expected = {"source": "source", "display_name": "source", "splits": []}
+        expected = {"source": "source", "display_name": "source", "splits": [], "top_k": None, "other_value": None}
         cohort = undertest.Cohort(source="source")
 
         assert expected == cohort.model_dump()
 
     def test_set_displayname(self):
-        expected = {"source": "source", "display_name": "display", "splits": []}
+        expected = {"source": "source", "display_name": "display", "splits": [], "top_k": None, "other_value": None}
         cohort = undertest.Cohort(source="source", display_name="display")
 
         assert expected == cohort.model_dump()
 
     def test_allows_splits(self):
         split_list = ["split1", "split2"]
-        expected = {"source": "source", "display_name": "source", "splits": split_list}
+        expected = {
+            "source": "source",
+            "display_name": "source",
+            "splits": split_list,
+            "top_k": None,
+            "other_value": None,
+        }
         cohort = undertest.Cohort(source="source", splits=split_list)
 
         assert expected == cohort.model_dump()
 
     def test_strips_other_keys(self):
-        expected = {"source": "source", "display_name": "source", "splits": []}
+        expected = {"source": "source", "display_name": "source", "splits": [], "top_k": None, "other_value": None}
         cohort = undertest.Cohort(source="source", other="other")
+
+        assert expected == cohort.model_dump()
+
+    def test_allows_other_string(self):
+        expected = {
+            "source": "source",
+            "display_name": "source",
+            "splits": [],
+            "top_k": 10,
+            "other_value": "SmallCounts",
+        }
+        cohort = undertest.Cohort(source="source", top_k=10, other_value="SmallCounts")
+
+        assert expected == cohort.model_dump()
+
+    def test_allows_other_number(self):
+        expected = {"source": "source", "display_name": "source", "splits": [], "top_k": 10, "other_value": 5}
+        cohort = undertest.Cohort(source="source", top_k=10, other_value=5)
 
         assert expected == cohort.model_dump()
 


### PR DESCRIPTION
# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->
Closes #xxx 

## Description of changes
Adds a cohort transform to allow renaming small count columns to an `other_value` group. 

```yaml
  cohorts:
    - source: many_values_column 
      display_name: All Different Values
    - source: many_values_column 
      display_name: Top 5 or Other
      top_k: 5
      other_value: "Other"
```

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
