### PR TITLE
minimal change for backwards compatibility post-otel

### DIFF
--- a/changelog/175.bugfix.rst
+++ b/changelog/175.bugfix.rst
@@ -1,0 +1,1 @@
+Initialize otel attribute on ConfigProvider

--- a/src/seismometer/__init__.py
+++ b/src/seismometer/__init__.py
@@ -73,9 +73,10 @@ def run_startup(
     initialize_otel_config(config)
 
     export_config = config.export_config
-    ExportManager(
-        hostname=export_config.hostname,
-        file_output_paths=export_config.otel_files,
-        export_ports=export_config.otel_ports,
-        dump_to_stdout=export_config.otel_stdout,
-    )
+    if export_config:
+        ExportManager(
+            hostname=export_config.hostname,
+            file_output_paths=export_config.otel_files,
+            export_ports=export_config.otel_ports,
+            dump_to_stdout=export_config.otel_stdout,
+        )

--- a/src/seismometer/configuration/config.py
+++ b/src/seismometer/configuration/config.py
@@ -64,6 +64,7 @@ class ConfigProvider:
         self._metrics: dict[str, Metric] = None
         self._metric_groups: dict = None
         self._metric_types: dict = None
+        self.export_config: ExportConfig = None
 
         if definitions is not None:
             self._prediction_defs = PredictionDictionary(predictions=definitions.pop("predictions", []))


### PR DESCRIPTION
# Overview
A seismograph could break if it extends ConfigProvider, since otel setup expects an attribute that isnt initialized.


## Description of changes
initialize config attr to None.  
skip the otel initialization if None

Will write up issue (#176) for more integrated solution, likely a from_config method that handles the none case internally producing the NoOp manager.

Considered sufficient for a fix

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
