### PR TITLE
Clean up dependency for OTEL manager classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ ENV/
 
 # Repository development directories
 .Trash-1000/
+.DS_Store
 /resources/
 /secrets/
 /secret/

--- a/docs/reference/internals.rst
+++ b/docs/reference/internals.rst
@@ -115,7 +115,6 @@ OpenTelemetry output
 .. autosummary::
    :toctree: api/
 
-   get_metric_creator
    deactivate_exports
    activate_exports
 

--- a/src/seismometer/__init__.py
+++ b/src/seismometer/__init__.py
@@ -12,7 +12,6 @@ import pandas as pd
 # API
 from seismometer.api import *
 from seismometer.core.autometrics import *
-from seismometer.data.otel import *
 
 __version__ = importlib.metadata.version("seismometer")
 logger = logging.getLogger("seismometer")
@@ -71,11 +70,3 @@ def run_startup(
     sg.load_data(predictions=predictions_frame, events=events_frame)
 
     initialize_otel_config(config)
-
-    export_config = config.export_config
-    ExportManager(
-        hostname=export_config.hostname,
-        file_output_paths=export_config.otel_files,
-        export_ports=export_config.otel_ports,
-        dump_to_stdout=export_config.otel_stdout,
-    )

--- a/src/seismometer/api/plots.py
+++ b/src/seismometer/api/plots.py
@@ -1126,7 +1126,7 @@ def binary_classifier_metric_evaluation(
     if isinstance(metrics, str):
         metrics = [metrics]
     stats = metric_generator.calculate_binary_stats(data, target, score_col, metrics)[0]
-    recorder = metric_apis.OpenTelemetryRecorder(name="Binary Classifier Evaluations", metric_names=metrics)
+    recorder = metric_apis.OpenTelemetryRecorder(metric_names=metrics, name="Binary Classifier Evaluations")
     attributes = {"score_col": score_col, "target": target}
     am = AutomationManager()
     for metric in metrics:

--- a/src/seismometer/configuration/config.py
+++ b/src/seismometer/configuration/config.py
@@ -64,6 +64,9 @@ class ConfigProvider:
         self._metrics: dict[str, Metric] = None
         self._metric_groups: dict = None
         self._metric_types: dict = None
+        self._automation_config: dict = {}
+        self._metric_config: MetricConfig = None
+        self.export_config: ExportConfig = None
 
         if definitions is not None:
             self._prediction_defs = PredictionDictionary(predictions=definitions.pop("predictions", []))

--- a/src/seismometer/core/autometrics.py
+++ b/src/seismometer/core/autometrics.py
@@ -12,6 +12,7 @@ import yaml
 from seismometer.configuration.config import ConfigProvider
 from seismometer.core.decorators import export
 from seismometer.core.patterns import Singleton
+from seismometer.data.otel import ExportManager
 from seismometer.data.performance import BinaryClassifierMetricGenerator
 
 logger = logging.getLogger("seismometer.telemetry")
@@ -282,6 +283,7 @@ def initialize_otel_config(config: ConfigProvider):
     config : OtherInfo
         The configuration object handed in during Seismogram initialization.
     """
+    ExportManager(config.export_config)
     am = AutomationManager(config_provider=config)
     am.load_automation_config(config)
     am.load_metric_config(config)

--- a/tests/data/test_otel.py
+++ b/tests/data/test_otel.py
@@ -1,4 +1,4 @@
-from seismometer.data.otel import RealExportManager
+from seismometer.data.otel import ExportConfig, RealExportManager
 
 
 class TestExportManager:
@@ -6,7 +6,8 @@ class TestExportManager:
         try:
             from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter  # noqa: F401
 
-            r = RealExportManager(hostname="", file_output_paths=[], export_ports=[], dump_to_stdout=True)
+            config = ExportConfig({"otel_export": {"stdout": True}})
+            r = RealExportManager(config)
             r.activate_exports()
             assert r.active
         except ModuleNotFoundError:
@@ -16,7 +17,8 @@ class TestExportManager:
         try:
             from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter  # noqa: F401
 
-            r = RealExportManager(hostname="", file_output_paths=[], export_ports=[], dump_to_stdout=True)
+            config = ExportConfig({"otel_export": {"stdout": True}})
+            r = RealExportManager(config)
             r.deactivate_exports()
             assert not r.active
         except ModuleNotFoundError:


### PR DESCRIPTION
AutomationManager depends on ExportManager
TelemetryRecorder depends on ExportManager and AutomationManager

ExportManager now accepts a single init param ExportConfig

Fixed related Unit tests.

# Overview
<!-- Update and delete as appropriate; useful reference when you get to news fragments -->
Closes #xxx 

## Description of changes
<!-- Describe your changes and any implementation decisions -->
<!-- Especially for enhancements, start conversations early. Ideally in the documenting issue -->
<!-- Can be formatted as a checklist for reviewers. -->

## Author Checklist
- [ ] Linting passes; run early with [pre-commit hook](https://pre-commit.com/#install).
- [ ] Tests added for new code and issue being fixed.
- [ ] Added type annotations and full numpy-style docstrings for new methods.
- [ ] Draft your news fragment in new `changelog/ISSUE.TYPE.rst` files; see [changelog/README.md](https://github.com/epic-open-source/seismometer/blob/main/changelog/README.md).
